### PR TITLE
新增YouTube视频解析功能

### DIFF
--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -126,6 +126,11 @@
                 "description": "是否启用Twitter/X解析器",
                 "type": "bool",
                 "default": true
+            },
+            "enable_youtube": {
+                "description": "是否启用YouTube(yt-dlp)解析器",
+                "type": "bool",
+                "default": true
             }
         }
     },
@@ -171,6 +176,18 @@
                         "description": "Twitter视频下载是否使用代理",
                         "type": "bool",
                         "hint": "启用后，Twitter视频下载将通过代理进行。视频CDN几乎不受影响，通常无需开启以节约流量",
+                        "default": true
+                    }
+                }
+            },
+            "youtube": {
+                "description": "YouTube代理设置",
+                "type": "object",
+                "items": {
+                    "use_proxy": {
+                        "description": "YouTube解析和下载是否使用代理",
+                        "type": "bool",
+                        "hint": "启用后，YouTube(yt-dlp)的解析和下载请求将通过代理进行",
                         "default": true
                     }
                 }

--- a/core/config_manager.py
+++ b/core/config_manager.py
@@ -1,153 +1,91 @@
 from typing import List
+import logging
 
 try:
     from astrbot.api import logger
 except ImportError:
-    import logging
     logger = logging.getLogger(__name__)
 
 from .constants import Config
 from .downloader.utils import check_cache_dir_available
 from .parser.platform import (
-    BilibiliParser,
-    DouyinParser,
-    KuaishouParser,
-    WeiboParser,
-    XiaohongshuParser,
-    XiaoheiheParser,
-    TwitterParser
+    BilibiliParser, DouyinParser, KuaishouParser, WeiboParser,
+    XiaohongshuParser, XiaoheiheParser, TwitterParser, YoutubeParser
 )
 
-
 class ConfigManager:
-
     def __init__(self, config: dict):
-        """初始化配置管理器
-
-        Args:
-            config: 原始配置字典
-
-        Raises:
-            ValueError: 没有启用任何解析器时
-        """
         self._config = config
         self._parse_config()
 
     def _parse_config(self):
-        """解析配置"""
-        self.is_auto_pack = self._config.get("is_auto_pack", True)
+        c = self._config
+        self.is_auto_pack = c.get("is_auto_pack", True)
         
-        trigger_settings = self._config.get("trigger_settings", {})
-        self.is_auto_parse = trigger_settings.get("is_auto_parse", True)
-        self.trigger_keywords = trigger_settings.get(
-            "trigger_keywords",
-            ["视频解析", "解析视频"]
-        )
+        ts = c.get("trigger_settings", {})
+        self.is_auto_parse = ts.get("is_auto_parse", True)
+        self.trigger_keywords = ts.get("trigger_keywords", ["视频解析", "解析视频"])
         
-        whitelist = self._config.get("whitelist", {})
-        self.whitelist_enable = whitelist.get("enable", False)
-        self.whitelist_user = whitelist.get("user", [])
-        self.whitelist_group = whitelist.get("group", [])
+        wl = c.get("whitelist", {})
+        self.whitelist_enable = wl.get("enable", False)
+        self.whitelist_user = wl.get("user", [])
+        self.whitelist_group = wl.get("group", [])
         
-        video_size_settings = self._config.get("video_size_settings", {})
-        self.max_video_size_mb = video_size_settings.get("max_video_size_mb", 0.0)
-        large_video_threshold_mb = video_size_settings.get(
-            "large_video_threshold_mb",
-            Config.MAX_LARGE_VIDEO_THRESHOLD_MB
-        )
-        if large_video_threshold_mb > 0:
-            large_video_threshold_mb = min(
-                large_video_threshold_mb,
-                Config.MAX_LARGE_VIDEO_THRESHOLD_MB
-            )
-        self.large_video_threshold_mb = large_video_threshold_mb
+        vss = c.get("video_size_settings", {})
+        self.max_video_size_mb = vss.get("max_video_size_mb", 0.0)
+        lvt = vss.get("large_video_threshold_mb", Config.MAX_LARGE_VIDEO_THRESHOLD_MB)
+        self.large_video_threshold_mb = min(lvt, Config.MAX_LARGE_VIDEO_THRESHOLD_MB) if lvt > 0 else 0.0
         
-        download_settings = self._config.get("download_settings", {})
-        self.cache_dir = download_settings.get(
-            "cache_dir",
-            "/app/sharedFolder/video_parser/cache"
-        )
-        self.pre_download_all_media = download_settings.get(
-            "pre_download_all_media",
-            False
-        )
-        self.max_concurrent_downloads = download_settings.get(
-            "max_concurrent_downloads",
-            Config.DOWNLOAD_MANAGER_MAX_CONCURRENT
-        )
+        ds = c.get("download_settings", {})
+        self.cache_dir = ds.get("cache_dir", "/app/sharedFolder/video_parser/cache")
+        self.pre_download_all_media = ds.get("pre_download_all_media", False)
+        self.max_concurrent_downloads = ds.get("max_concurrent_downloads", Config.DOWNLOAD_MANAGER_MAX_CONCURRENT)
         
-        if self.pre_download_all_media:
-            if not check_cache_dir_available(self.cache_dir):
-                logger.warning(
-                    f"预下载模式已启用，但缓存目录不可用: {self.cache_dir}，"
-                    f"将自动降级为禁用预下载模式"
-                )
-                self.pre_download_all_media = False
+        if self.pre_download_all_media and not check_cache_dir_available(self.cache_dir):
+            logger.warning(f"预下载模式已启用，但缓存目录不可用: {self.cache_dir}，将自动降级为禁用")
+            self.pre_download_all_media = False
         
-        parser_enable_settings = self._config.get("parser_enable_settings", {})
-        self.enable_bilibili = parser_enable_settings.get("enable_bilibili", True)
-        self.enable_douyin = parser_enable_settings.get("enable_douyin", True)
-        self.enable_kuaishou = parser_enable_settings.get(
-            "enable_kuaishou",
-            True
-        )
-        self.enable_weibo = parser_enable_settings.get(
-            "enable_weibo",
-            True
-        )
-        self.enable_xiaohongshu = parser_enable_settings.get(
-            "enable_xiaohongshu",
-            True
-        )
-        self.enable_xiaoheihe = parser_enable_settings.get(
-            "enable_xiaoheihe",
-            True
-        )
-        self.enable_twitter = parser_enable_settings.get("enable_twitter", True)
+        pes = c.get("parser_enable_settings", {})
+        self.enable_bilibili = pes.get("enable_bilibili", True)
+        self.enable_douyin = pes.get("enable_douyin", True)
+        self.enable_kuaishou = pes.get("enable_kuaishou", True)
+        self.enable_weibo = pes.get("enable_weibo", True)
+        self.enable_xiaohongshu = pes.get("enable_xiaohongshu", True)
+        self.enable_xiaoheihe = pes.get("enable_xiaoheihe", True)
+        self.enable_twitter = pes.get("enable_twitter", True)
+        self.enable_youtube = pes.get("enable_youtube", True)
         
-        proxy_settings = self._config.get("proxy_settings", {})
-        self.proxy_addr = proxy_settings.get("proxy_addr", "")
+        ps = c.get("proxy_settings", {})
+        self.proxy_addr = ps.get("proxy_addr", "")
         
-        xiaoheihe_proxy = proxy_settings.get("xiaoheihe", {})
-        self.xiaoheihe_use_video_proxy = xiaoheihe_proxy.get("video", False)
+        self.xiaoheihe_use_video_proxy = ps.get("xiaoheihe", {}).get("video", False)
         
-        twitter_proxy = proxy_settings.get("twitter", {})
-        self.twitter_use_parse_proxy = twitter_proxy.get("parse", False)
-        self.twitter_use_image_proxy = twitter_proxy.get("image", False)
-        self.twitter_use_video_proxy = twitter_proxy.get("video", False)
+        tw = ps.get("twitter", {})
+        self.twitter_use_parse_proxy = tw.get("parse", False)
+        self.twitter_use_image_proxy = tw.get("image", False)
+        self.twitter_use_video_proxy = tw.get("video", False)
         
-        self.debug_mode = self._config.get("debug", False)
+        self.youtube_use_proxy = ps.get("youtube", {}).get("use_proxy", True)
+
+        self.debug_mode = c.get("debug", False)
         if self.debug_mode:
-            import logging
             logger.setLevel(logging.DEBUG)
             logger.debug("Debug模式已启用")
 
     def create_parsers(self) -> List:
-        """创建解析器列表
-
-        Returns:
-            解析器列表
-
-        Raises:
-            ValueError: 没有启用任何解析器时
-        """
         parsers = []
+        if self.enable_bilibili: parsers.append(BilibiliParser())
+        if self.enable_douyin: parsers.append(DouyinParser())
+        if self.enable_kuaishou: parsers.append(KuaishouParser())
+        if self.enable_weibo: parsers.append(WeiboParser())
+        if self.enable_xiaohongshu: parsers.append(XiaohongshuParser())
         
-        if self.enable_bilibili:
-            parsers.append(BilibiliParser())
-        if self.enable_douyin:
-            parsers.append(DouyinParser())
-        if self.enable_kuaishou:
-            parsers.append(KuaishouParser())
-        if self.enable_weibo:
-            parsers.append(WeiboParser())
-        if self.enable_xiaohongshu:
-            parsers.append(XiaohongshuParser())
         if self.enable_xiaoheihe:
             parsers.append(XiaoheiheParser(
                 use_video_proxy=self.xiaoheihe_use_video_proxy,
                 proxy_url=self.proxy_addr if self.proxy_addr else None
             ))
+            
         if self.enable_twitter:
             parsers.append(TwitterParser(
                 use_parse_proxy=self.twitter_use_parse_proxy,
@@ -155,12 +93,14 @@ class ConfigManager:
                 use_video_proxy=self.twitter_use_video_proxy,
                 proxy_url=self.proxy_addr if self.proxy_addr else None
             ))
+            
+        if self.enable_youtube:
+            parsers.append(YoutubeParser(
+                use_proxy=self.youtube_use_proxy,
+                proxy_url=self.proxy_addr if self.proxy_addr else None
+            ))
         
         if not parsers:
-            raise ValueError(
-                "至少需要启用一个视频解析器。"
-                "请检查配置中的 parser_enable_settings 设置。"
-            )
-        
+            raise ValueError("至少需要启用一个视频解析器。请检查配置。")
+            
         return parsers
-

--- a/core/downloader/handler/__init__.py
+++ b/core/downloader/handler/__init__.py
@@ -1,8 +1,8 @@
 from .normal_video import batch_download_videos
 from .m3u8 import M3U8Handler
-
-__all__ = [
-    'batch_download_videos',
-    'M3U8Handler'
+from .ytdlp import download_ytdlp_to_cache
+all =[
+'batch_download_videos',
+'M3U8Handler',
+'download_ytdlp_to_cache'
 ]
-

--- a/core/downloader/handler/ytdlp.py
+++ b/core/downloader/handler/ytdlp.py
@@ -1,0 +1,86 @@
+import asyncio
+import os
+from typing import Dict, Any, Optional
+
+import aiohttp
+import yt_dlp
+import imageio_ffmpeg
+
+try:
+    from astrbot.api import logger
+except ImportError:
+    import logging
+    logger = logging.getLogger(__name__)
+
+
+async def download_ytdlp_to_cache(
+    session: aiohttp.ClientSession,
+    video_url: str,
+    cache_dir: str,
+    media_id: str,
+    index: int = 0,
+    headers: dict = None,
+    proxy: str = None
+) -> Optional[Dict[str, Any]]:
+    if not cache_dir:
+        return None
+
+    try:
+        ffmpeg_exe = imageio_ffmpeg.get_ffmpeg_exe()
+    except Exception:
+        ffmpeg_exe = "ffmpeg"
+
+    cache_dir = os.path.normpath(cache_dir)
+    cache_subdir = os.path.join(cache_dir, media_id)
+    
+    if not os.path.exists(cache_subdir):
+        os.makedirs(cache_subdir, exist_ok=True)
+        
+    outtmpl = os.path.join(os.path.abspath(cache_subdir), f"video_{index}.%(ext)s")
+    
+    opts = {
+        "outtmpl": outtmpl,
+        "format": "bestvideo+bestaudio/best",
+        "merge_output_format": "mp4",
+        # 即使没有 Cookie，使用 Android 客户端伪装也能提高普通视频的下载成功率
+        "extractor_args": {'youtube': {'player_client': ['android']}},
+        "noplaylist": True,
+        "quiet": True,
+        "ffmpeg_location": ffmpeg_exe
+    }
+    if proxy:
+        opts["proxy"] = proxy
+    
+    def _download():
+        with yt_dlp.YoutubeDL(opts) as ydl:
+            info = ydl.extract_info(video_url, download=True)
+            return ydl.prepare_filename(info)
+
+    try:
+        logger.debug(f"开始使用yt-dlp下载: {video_url} -> {outtmpl}")
+        final_path = await asyncio.get_running_loop().run_in_executor(None, _download)
+        
+        if final_path:
+            final_path = os.path.normpath(final_path)
+        
+        if not os.path.exists(final_path):
+            base = os.path.splitext(final_path)[0]
+            for ext in ['.mp4', '.mkv', '.webm']:
+                candidate = base + ext
+                if os.path.exists(candidate):
+                    final_path = candidate
+                    break
+
+        if os.path.exists(final_path):
+            size_mb = os.path.getsize(final_path) / (1024 * 1024)
+            logger.debug(f"yt-dlp下载完成: {final_path}, size: {size_mb:.2f}MB")
+            return {
+                'file_path': final_path,
+                'size_mb': size_mb
+            }
+        
+        logger.error(f"yt-dlp 下载似已完成但文件不存在: {final_path}")
+        return None
+    except Exception as e:
+        logger.warning(f"yt-dlp下载失败: {video_url}, 错误: {e}")
+        return None

--- a/core/downloader/manager.py
+++ b/core/downloader/manager.py
@@ -30,16 +30,7 @@ class DownloadManager:
         pre_download_all_media: bool = False,
         max_concurrent_downloads: int = None
     ):
-        """初始化下载管理器
-
-        Args:
-            max_video_size_mb: 最大允许的视频大小(MB)，0表示不限制
-            large_video_threshold_mb: 大视频阈值(MB)，超过此大小将单独发送。
-                当设置为0时，所有视频都使用直链，不进行本地下载（与max_video_size_mb=0时的行为类似）
-            cache_dir: 视频缓存目录
-            pre_download_all_media: 是否预先下载所有媒体到本地
-            max_concurrent_downloads: 最大并发下载数
-        """
+        """初始化下载管理器"""
         self.max_video_size_mb = max_video_size_mb
         if large_video_threshold_mb > 0:
             self.large_video_threshold_mb = min(
@@ -56,8 +47,8 @@ class DownloadManager:
         )
         self.effective_pre_download = pre_download_all_media and check_cache_dir_available(cache_dir)
         
-        self._active_sessions: List[aiohttp.ClientSession] = []
-        self._active_tasks: List[asyncio.Task] = []
+        self._active_sessions: List[aiohttp.ClientSession] =[]
+        self._active_tasks: List[asyncio.Task] =[]
         self._shutting_down = False
 
     async def _download_one_image(
@@ -68,18 +59,6 @@ class DownloadManager:
         metadata: Dict[str, Any],
         proxy_addr: str = None
     ) -> Optional[str]:
-        """下载单个图片，遍历URL列表，每个URL只尝试一次
-
-        Args:
-            session: aiohttp会话
-            url_list: 图片URL列表
-            img_idx: 图片索引
-            metadata: 元数据字典（用于获取 header 参数）
-            proxy_addr: 代理地址（可选）
-
-        Returns:
-            临时文件路径，失败时为None
-        """
         if not url_list or not isinstance(url_list, list):
             return None
         
@@ -112,26 +91,14 @@ class DownloadManager:
         metadata: Dict[str, Any],
         proxy_addr: str = None
     ) -> Tuple[List[Optional[str]], int]:
-        """下载所有图片到临时文件
-
-        Args:
-            session: aiohttp会话
-            image_urls: 图片URL列表（二维列表）
-            has_valid_images: 是否有有效的图片
-            metadata: 元数据字典（用于获取 header 参数）
-            proxy_addr: 代理地址（可选）
-
-        Returns:
-            (image_file_paths, failed_image_count) 元组
-        """
-        image_file_paths = []
+        image_file_paths =[]
         failed_image_count = 0
 
         if image_urls and has_valid_images:
             if self._shutting_down:
                 return image_file_paths, len(image_urls)
             
-            coros = [
+            coros =[
                 self._download_one_image(
                     session, url_list, idx, metadata, proxy_addr
                 )
@@ -170,17 +137,6 @@ class DownloadManager:
         metadata: Dict[str, Any],
         proxy_addr: str = None
     ) -> Tuple[Optional[float], Optional[int]]:
-        """获取视频大小任务（异步函数）
-        
-        Args:
-            session: aiohttp会话
-            url_list: 视频URL列表
-            metadata: 元数据字典（用于获取 header 参数）
-            proxy_addr: 代理地址（可选）
-            
-        Returns:
-            (size_mb, status_code) 元组
-        """
         if not url_list:
             return None, None
         try:
@@ -193,6 +149,8 @@ class DownloadManager:
                 video_url = video_url[5:]
             elif video_url.startswith('range:'):
                 video_url = video_url[6:]
+            elif video_url.startswith('ytdlp:'):
+                return None, None
             return await get_video_size(session, video_url, headers, proxy)
         except Exception:
             return None, None
@@ -204,26 +162,13 @@ class DownloadManager:
         metadata: Dict[str, Any],
         proxy_addr: str = None
     ) -> Tuple[List[Optional[float]], bool]:
-        """检查所有视频的大小
-        
-        Args:
-            session: aiohttp会话
-            video_urls: 视频URL列表（二维列表）
-            metadata: 元数据字典
-            proxy_addr: 代理地址（可选）
-            
-        Returns:
-            (video_sizes, has_access_denied) 元组
-            video_sizes: 视频大小列表(MB)，None表示获取失败
-            has_access_denied: 是否有403访问被拒绝
-        """
-        video_sizes = []
+        video_sizes =[]
         has_access_denied = False
         
         if self._shutting_down:
             return [None] * len(video_urls), False
         
-        coros = [
+        coros =[
             self._get_video_size_task(session, url_list, metadata, proxy_addr)
             for url_list in video_urls
         ]
@@ -259,18 +204,6 @@ class DownloadManager:
         video_sizes: List[Optional[float]],
         url: str
     ) -> Tuple[bool, Optional[float], float]:
-        """检查视频大小是否超过限制
-        
-        Args:
-            video_sizes: 视频大小列表(MB)
-            url: 原始URL（用于日志）
-            
-        Returns:
-            (exceeds_limit, max_video_size, total_video_size) 元组
-            exceeds_limit: 是否超过限制
-            max_video_size: 最大视频大小(MB)
-            total_video_size: 总视频大小(MB)
-        """
         if self.max_video_size_mb <= 0:
             return False, None, 0.0
         
@@ -299,19 +232,6 @@ class DownloadManager:
         video_count: int,
         image_count: int
     ) -> Dict[str, Any]:
-        """创建超过大小限制的元数据
-        
-        Args:
-            metadata: 原始元数据
-            video_sizes: 视频大小列表
-            max_video_size: 最大视频大小(MB)
-            total_video_size: 总视频大小(MB)
-            video_count: 视频数量
-            image_count: 图片数量
-            
-        Returns:
-            更新后的元数据
-        """
         metadata['exceeds_max_size'] = True
         metadata['has_valid_media'] = False
         metadata['video_sizes'] = video_sizes
@@ -331,19 +251,9 @@ class DownloadManager:
         media_id: str,
         proxy_addr: str = None
     ) -> List[Dict[str, Any]]:
-        """构建媒体项列表
-
-        Args:
-            metadata: 元数据字典（应包含 image_headers, video_headers 字段）
-            media_id: 媒体ID
-            proxy_addr: 代理地址（可选，优先级低于元数据中的 proxy_url）
-
-        Returns:
-            媒体项列表，每个项包含url_list（URL列表）、media_id、index、is_video、headers等字段
-        """
-        media_items = []
+        media_items =[]
         video_urls = metadata.get('video_urls', [])
-        image_urls = metadata.get('image_urls', [])
+        image_urls = metadata.get('image_urls',[])
         
         use_image_proxy = metadata.get('use_image_proxy', False)
         use_video_proxy = metadata.get('use_video_proxy', False)
@@ -387,17 +297,7 @@ class DownloadManager:
         expected_count: int,
         start_idx: int = 0
     ) -> Tuple[List[Optional[str]], int]:
-        """处理单一类型的下载结果（视频或图片）
-
-        Args:
-            download_results: 下载结果列表
-            expected_count: 期望的结果数量
-            start_idx: 开始索引（用于处理部分结果）
-
-        Returns:
-            (file_paths, failed_count) 元组
-        """
-        file_paths = []
+        file_paths =[]
         failed_count = 0
         
         for idx in range(expected_count):
@@ -423,22 +323,8 @@ class DownloadManager:
         cache_dir: str,
         max_concurrent: int = None
     ) -> List[Dict[str, Any]]:
-        """批量下载媒体到缓存目录（支持视频和图片混合）
-        
-        此方法会根据媒体类型使用相应的下载器（通过 router.download_media）
-
-        Args:
-            session: aiohttp会话
-            media_items: 媒体项列表，每个项包含url_list（URL列表）、media_id、index、
-                headers、proxy等字段
-            cache_dir: 缓存目录路径
-            max_concurrent: 最大并发下载数
-
-        Returns:
-            下载结果列表，每个项包含url（第一个URL）、file_path、success、index等字段
-        """
         if not cache_dir or not media_items:
-            return []
+            return[]
 
         if max_concurrent is None:
             max_concurrent = self.max_concurrent_downloads
@@ -447,7 +333,7 @@ class DownloadManager:
         async def download_one(item: Dict[str, Any]) -> Dict[str, Any]:
             async with semaphore:
                 try:
-                    url_list = item.get('url_list', [])
+                    url_list = item.get('url_list',[])
                     media_id = item.get('media_id', 'media')
                     index = item.get('index', 0)
                     item_headers = item.get('headers', {})
@@ -489,7 +375,7 @@ class DownloadManager:
                         'index': index
                     }
                 except Exception as e:
-                    url_list = item.get('url_list', [])
+                    url_list = item.get('url_list',[])
                     index = item.get('index', 0)
                     logger.warning(f"批量下载媒体失败: {url_list[0] if url_list else 'unknown'}, 错误: {e}")
                     return {
@@ -510,16 +396,6 @@ class DownloadManager:
         video_urls: List[List[str]],
         image_urls: List[List[str]]
     ) -> Tuple[List[Optional[str]], int, int]:
-        """处理下载结果，构建文件路径列表并统计失败数量
-
-        Args:
-            download_results: 下载结果列表
-            video_urls: 视频URL列表（二维列表）
-            image_urls: 图片URL列表（二维列表）
-
-        Returns:
-            (file_paths, failed_video_count, failed_image_count) 元组
-        """
         video_file_paths, failed_video_count = self._process_single_type_results(
             download_results, len(video_urls), start_idx=0
         )
@@ -535,16 +411,6 @@ class DownloadManager:
         metadata: Dict[str, Any],
         proxy_addr: str = None
     ) -> Dict[str, Any]:
-        """处理元数据，根据下载模式决定媒体处理方式
-
-        Args:
-            session: aiohttp会话
-            metadata: 解析后的元数据（应包含 image_headers, video_headers 字段）
-            proxy_addr: 代理地址（可选，用于 Twitter 等需要代理的平台）
-
-        Returns:
-            处理后的元数据，包含视频大小信息和文件路径信息
-        """
         if self._shutting_down:
             return metadata
         
@@ -556,7 +422,7 @@ class DownloadManager:
 
         url = metadata.get('url', '')
         video_urls = metadata.get('video_urls', [])
-        image_urls = metadata.get('image_urls', [])
+        image_urls = metadata.get('image_urls',[])
         
         if 'image_headers' not in metadata:
             metadata['image_headers'] = {}
@@ -565,15 +431,22 @@ class DownloadManager:
         
         video_force_download = metadata.get('video_force_download', False)
         
+        # 强制 YouTube 启用预下载
+        has_ytdlp = any(
+            u and u.startswith('ytdlp:')
+            for url_list in video_urls for u in url_list
+        )
+        current_effective_pre_download = self.effective_pre_download or (has_ytdlp and check_cache_dir_available(self.cache_dir))
+        
         logger.debug(
             f"处理元数据: {url}, "
             f"video_force_download={video_force_download}, "
-            f"effective_pre_download={self.effective_pre_download}"
+            f"effective_pre_download={current_effective_pre_download}"
         )
         
         video_count = len(video_urls)
         image_count = len(image_urls)
-        video_sizes = []
+        video_sizes =[]
         
         if video_urls and self.max_video_size_mb > 0:
             logger.debug(f"开始检查视频大小: {url}, 视频数量: {len(video_urls)}")
@@ -591,7 +464,7 @@ class DownloadManager:
                     video_count, image_count
                 )
         
-        if self.effective_pre_download:
+        if current_effective_pre_download:
             logger.debug(f"开始批量下载所有媒体: {url}, 视频: {len(video_urls)}, 图片: {len(image_urls)}")
             media_id = self._generate_media_id(url, metadata)
             media_items = self._build_media_items(
@@ -615,12 +488,12 @@ class DownloadManager:
             
             if video_force_download:
                 original_video_count = len(video_urls)
-                video_results = download_results[:original_video_count] if original_video_count > 0 else []
+                video_results = download_results[:original_video_count] if original_video_count > 0 else[]
                 all_video_failed = all(not result.get('success') for result in video_results) if video_results else False
                 if all_video_failed and original_video_count > 0:
                     logger.debug(f"视频要求强制下载但全部失败，跳过所有视频: {url}")
                     video_urls = []
-                    metadata['video_urls'] = []
+                    metadata['video_urls'] =[]
                     for idx in range(original_video_count):
                         if idx < len(file_paths):
                             file_paths[idx] = None
@@ -640,7 +513,7 @@ class DownloadManager:
                     else:
                         final_video_sizes.append(None)
                 
-                valid_sizes = [s for s in final_video_sizes if s is not None]
+                valid_sizes =[s for s in final_video_sizes if s is not None]
                 max_video_size = max(valid_sizes) if valid_sizes else None
                 total_video_size = sum(valid_sizes) if valid_sizes else 0.0
                 
@@ -681,7 +554,7 @@ class DownloadManager:
             if video_force_download:
                 logger.debug(f"视频要求强制下载但未启用批量下载，跳过所有视频: {url}")
                 video_urls = []
-                metadata['video_urls'] = []
+                metadata['video_urls'] =[]
             
             video_has_access_denied = False
             if video_urls:
@@ -697,7 +570,7 @@ class DownloadManager:
             
             has_valid_images = False
             has_access_denied = False
-            image_file_paths = []
+            image_file_paths =[]
             failed_image_count = 0
             
             if image_urls:
@@ -720,7 +593,7 @@ class DownloadManager:
             if not has_valid_media:
                 metadata['exceeds_max_size'] = False
                 metadata['file_paths'] = image_file_paths
-                metadata['use_local_files'] = has_valid_images  # 只有图片可能使用本地文件
+                metadata['use_local_files'] = has_valid_images
                 metadata['failed_video_count'] = len(video_urls) if video_urls else 0
                 metadata['failed_image_count'] = failed_image_count
                 return metadata
@@ -749,15 +622,6 @@ class DownloadManager:
             return metadata
 
     def _generate_media_id(self, url: str, metadata: Optional[Dict[str, Any]] = None) -> str:
-        """根据URL生成媒体目录名，格式：{platform}_{url_hash}_{timestamp}
-
-        Args:
-            url: 原始URL
-            metadata: 元数据字典（可选），应包含platform字段
-
-        Returns:
-            媒体目录名
-        """
         platform = 'unknown'
         if metadata and 'platform' in metadata:
             platform = metadata.get('platform')
@@ -772,10 +636,6 @@ class DownloadManager:
         return f"{platform}_{url_hash}_{timestamp}"
 
     async def shutdown(self):
-        """关闭所有活动的下载任务和会话
-        
-        终止所有正在进行的下载任务，关闭所有活动的 aiohttp 会话
-        """
         self._shutting_down = True
         
         for session in self._active_sessions:
@@ -790,4 +650,3 @@ class DownloadManager:
         if self._active_tasks:
             await asyncio.gather(*self._active_tasks, return_exceptions=True)
         self._active_tasks.clear()
-

--- a/core/downloader/router.py
+++ b/core/downloader/router.py
@@ -7,17 +7,10 @@ from .handler.image import download_image_to_cache
 from .handler.normal_video import download_video_to_cache
 from .handler.range_video import download_video_to_cache as download_range_video_to_cache
 from .handler.m3u8 import M3U8Handler
+from .handler.ytdlp import download_ytdlp_to_cache
 
 
 def detect_media_type(url: str) -> Literal['m3u8', 'image', 'video']:
-    """检测媒体类型
-
-    Args:
-        url: 媒体URL
-
-    Returns:
-        媒体类型：'m3u8'、'image' 或 'video'
-    """
     if not url:
         return 'video'
     
@@ -28,8 +21,8 @@ def detect_media_type(url: str) -> Literal['m3u8', 'image', 'video']:
         return 'm3u8'
     
     media_types = {
-        'image': ['jpg', 'jpeg', 'png', 'gif', 'webp', 'bmp', 'svg'],
-        'video': ['mp4', 'mkv', 'mov', 'avi', 'flv', 'f4v', 'webm', 'wmv', 'm4v']
+        'image':['jpg', 'jpeg', 'png', 'gif', 'webp', 'bmp', 'svg'],
+        'video':['mp4', 'mkv', 'mov', 'avi', 'flv', 'f4v', 'webm', 'wmv', 'm4v']
     }
     
     for media_type, extensions in media_types.items():
@@ -71,25 +64,21 @@ async def download_media(
     m3u8_handler: Optional[M3U8Handler] = None,
     use_ffmpeg: bool = True
 ) -> Optional[Dict[str, Any]]:
-    """下载媒体文件
-
-    Args:
-        session: aiohttp会话
-        media_url: 媒体URL
-        media_type: 媒体类型（可选，如果不提供会自动检测）
-        cache_dir: 缓存目录
-        media_id: 媒体ID
-        index: 媒体索引
-        headers: 请求头字典
-        proxy: 代理地址（可选）
-        m3u8_handler: M3U8处理器（可选）
-        use_ffmpeg: 是否使用ffmpeg（仅用于M3U8）
-
-    Returns:
-        下载结果字典，包含file_path和size_mb字段，失败时为None
-    """
     actual_url = media_url
-    if media_url.startswith('m3u8:'):
+    if media_url.startswith('ytdlp:'):
+        actual_url = media_url[6:]
+        if not cache_dir:
+            return None
+        return await download_ytdlp_to_cache(
+            session=session,
+            video_url=actual_url,
+            cache_dir=cache_dir,
+            media_id=media_id or 'media',
+            index=index,
+            headers=headers,
+            proxy=proxy
+        )
+    elif media_url.startswith('m3u8:'):
         actual_url = media_url[5:]
         media_type = 'm3u8'
     elif media_type is None:

--- a/core/downloader/validator.py
+++ b/core/downloader/validator.py
@@ -25,18 +25,6 @@ async def validate_media_response(
     is_video: bool = False,
     allow_read_content: bool = True
 ) -> Tuple[bool, Optional[bytes]]:
-    """验证响应是否为有效的媒体响应
-
-    Args:
-        response: HTTP响应对象
-        media_url: 媒体URL（用于日志）
-        is_video: 是否为视频（True为视频，False为图片）
-        allow_read_content: 是否允许读取内容（HEAD请求时为False）
-
-    Returns:
-        (is_valid, content_preview) 元组，is_valid表示是否为有效媒体，
-        content_preview为已读取的内容预览（如果Content-Type为空且允许读取）
-    """
     if response.status != 200:
         if response.status == 403:
             logger.warning(f"媒体URL访问被拒绝(403 Forbidden): {media_url}")
@@ -73,22 +61,12 @@ async def get_video_size(
     headers: dict = None,
     proxy: str = None
 ) -> Tuple[Optional[float], Optional[int]]:
-    """获取视频文件大小
-
-    Args:
-        session: aiohttp会话
-        video_url: 视频URL
-        headers: 请求头（可选）
-        proxy: 代理地址（可选）
-
-    Returns:
-        (size_mb, status_code) 元组，size_mb为视频大小(MB)，无法获取时为None，
-        status_code为HTTP状态码（如果是403等特殊状态码），否则为None
-    """
     if video_url.startswith('m3u8:'):
         video_url = video_url[5:]
     elif video_url.startswith('range:'):
         video_url = video_url[6:]
+    elif video_url.startswith('ytdlp:'):
+        return None, None
     
     try:
         request_headers = headers or {}
@@ -145,23 +123,12 @@ async def validate_media_url(
     proxy: str = None,
     is_video: bool = True
 ) -> Tuple[bool, Optional[int]]:
-    """验证媒体URL是否有效
-
-    Args:
-        session: aiohttp会话
-        media_url: 媒体URL
-        headers: 请求头（可选）
-        proxy: 代理地址（可选）
-        is_video: 是否为视频（True为视频，False为图片）
-
-    Returns:
-        (is_valid, status_code) 元组，is_valid表示媒体URL是否有效，
-        status_code为HTTP状态码（如果是403等特殊状态码），否则为None
-    """
     if media_url.startswith('m3u8:'):
         media_url = media_url[5:]
     elif media_url.startswith('range:'):
         media_url = media_url[6:]
+    elif media_url.startswith('ytdlp:'):
+        return True, None
     
     try:
         request_headers = headers or {}
@@ -199,4 +166,3 @@ async def validate_media_url(
         if '403' in str(e) or 'Forbidden' in str(e):
             return False, 403
         return False, None
-

--- a/core/parser/platform/__init__.py
+++ b/core/parser/platform/__init__.py
@@ -5,16 +5,16 @@ from .weibo import WeiboParser
 from .xiaohongshu import XiaohongshuParser
 from .xiaoheihe import XiaoheiheParser
 from .twitter import TwitterParser
+from .youtube import YoutubeParser
 from .base import BaseVideoParser
-
-__all__ = [
-    'BilibiliParser',
-    'DouyinParser',
-    'KuaishouParser',
-    'WeiboParser',
-    'XiaohongshuParser',
-    'XiaoheiheParser',
-    'TwitterParser',
-    'BaseVideoParser'
+all =[
+'BilibiliParser',
+'DouyinParser',
+'KuaishouParser',
+'WeiboParser',
+'XiaohongshuParser',
+'XiaoheiheParser',
+'TwitterParser',
+'YoutubeParser',
+'BaseVideoParser'
 ]
-

--- a/core/parser/platform/youtube.py
+++ b/core/parser/platform/youtube.py
@@ -1,0 +1,97 @@
+import asyncio
+import re
+from typing import Optional, Dict, Any, List
+
+import yt_dlp
+import aiohttp
+
+try:
+    from astrbot.api import logger
+except ImportError:
+    import logging
+    logger = logging.getLogger(__name__)
+
+from .base import BaseVideoParser
+from ...constants import Config
+
+
+class YoutubeParser(BaseVideoParser):
+    def __init__(
+        self,
+        use_proxy: bool = False,
+        proxy_url: str = None
+    ):
+        super().__init__("youtube")
+        self.use_proxy = use_proxy
+        self.proxy_url = proxy_url
+        self.semaphore = asyncio.Semaphore(Config.PARSER_MAX_CONCURRENT)
+
+    def can_parse(self, url: str) -> bool:
+        if not url: 
+            return False
+        url_lower = url.lower()
+        return 'youtube.com' in url_lower or 'youtu.be' in url_lower
+
+    def extract_links(self, text: str) -> List[str]:
+        pattern = r'https?://(?:www\.)?(?:youtube\.com/watch\?v=|youtu\.be/)[a-zA-Z0-9_-]+'
+        return list(set(re.findall(pattern, text)))
+
+    async def parse(
+        self,
+        session: aiohttp.ClientSession,
+        url: str
+    ) -> Optional[Dict[str, Any]]:
+        async with self.semaphore:
+            opts = {
+                "quiet": True,
+                "no_warnings": True,
+                "nocheckcertificate": True,
+                "extract_flat": True, 
+                "skip_download": True,
+            }
+            
+            if self.use_proxy and self.proxy_url:
+                opts["proxy"] = self.proxy_url
+
+            def _extract():
+                with yt_dlp.YoutubeDL(opts) as ydl:
+                    return ydl.extract_info(url, download=False)
+
+            try:
+                logger.debug(f"[{self.name}] parse: 开始解析 {url}")
+                info = await asyncio.get_running_loop().run_in_executor(None, _extract)
+            except Exception as e:
+                err_str = str(e)
+                # 专门捕获年龄限制错误，返回更友好的提示
+                if "Sign in to confirm your age" in err_str:
+                    logger.warning(f"[{self.name}] 视频有年龄限制: {url}")
+                    raise RuntimeError("该视频有年龄限制，无法免登录解析。")
+                
+                logger.error(f"yt-dlp 解析错误: {e}")
+                raise RuntimeError(f"yt-dlp解析失败: {e}")
+
+            if not info:
+                raise RuntimeError("无法获取YouTube视频信息")
+
+            title = info.get('title', 'YouTube Video')
+            author = info.get('uploader', '')
+            desc = info.get('description', '')
+            timestamp = ""
+            upload_date = info.get('upload_date')
+            if upload_date and len(upload_date) == 8:
+                timestamp = f"{upload_date[:4]}-{upload_date[4:6]}-{upload_date[6:]}"
+
+            return {
+                "url": url,
+                "title": title,
+                "author": author,
+                "desc": desc[:200] + "..." if desc and len(desc) > 200 else desc,
+                "timestamp": timestamp,
+                "video_urls": [[f"ytdlp:{url}"]],
+                "image_urls": [],
+                "image_headers": {},
+                "video_headers": {},
+                "video_force_download": True,
+                "use_video_proxy": self.use_proxy,
+                "proxy_url": self.proxy_url if self.use_proxy else None
+            }

--- a/main.py
+++ b/main.py
@@ -3,6 +3,7 @@ import json
 from typing import Any, Dict
 
 import aiohttp
+import yt_dlp
 
 try:
     from astrbot.api import logger
@@ -10,6 +11,7 @@ except ImportError:
     import logging
     logger = logging.getLogger(__name__)
 
+from astrbot.api.all import command
 from astrbot.api.event import filter, AstrMessageEvent
 from astrbot.api.star import Context, Star, register
 from astrbot.core.star.filter.event_message_type import EventMessageType
@@ -31,15 +33,7 @@ from .core.config_manager import ConfigManager
 class VideoParserPlugin(Star):
 
     def __init__(self, context: Context, config: dict):
-        """初始化插件
-
-        Args:
-            context: 上下文对象
-            config: 配置字典
-
-        Raises:
-            ValueError: 没有启用任何解析器时
-        """
+        """初始化插件"""
         super().__init__(context)
         self.logger = logger
         
@@ -80,14 +74,6 @@ class VideoParserPlugin(Star):
             cleanup_directory(self.download_manager.cache_dir)
 
     def _should_parse(self, message_str: str) -> bool:
-        """判断是否应该解析消息
-
-        Args:
-            message_str: 消息文本
-
-        Returns:
-            是否应该解析
-        """
         if self.is_auto_parse:
             return True
         for keyword in self.trigger_keywords:
@@ -95,15 +81,110 @@ class VideoParserPlugin(Star):
                 return True
         return False
 
+    @command("直链")
+    async def cmd_get_direct_url(self, event: AstrMessageEvent, url: str = ""):
+        """提取视频直链，不下载"""
+        raw = event.message_str
+        full_url = url
+        for prefix in ["/直链 ", "直链 "]:
+            if prefix in raw:
+                full_url = raw.split(prefix, 1)[1].strip()
+                break
+        if not full_url:
+            await event.send(event.plain_result("❌ 请提供视频链接，例如: /直链 https://youtube.com/watch?v=..."))
+            return
+
+        await event.send(event.plain_result("⏳ 正在解析直链，请稍候..."))
+
+        opts = {
+            "quiet": True,
+            "no_warnings": True,
+            "nocheckcertificate": True,
+            "noplaylist": True,
+            "skip_download": True,
+        }
+        if self.proxy_addr:
+            opts["proxy"] = self.proxy_addr
+
+        try:
+            def _extract():
+                with yt_dlp.YoutubeDL(opts) as ydl:
+                    return ydl.extract_info(full_url, download=False)
+
+            info = await asyncio.get_running_loop().run_in_executor(None, _extract)
+        except Exception as e:
+            await event.send(event.plain_result(f"❌ 解析失败: {e}"))
+            return
+
+        if not info:
+            await event.send(event.plain_result("❌ 无法获取视频信息。"))
+            return
+
+        title = info.get("title", "未知标题")
+        duration = info.get("duration")
+        dur_str = f"{int(duration)//60}:{int(duration)%60:02d}" if duration else "未知"
+
+        direct_url = info.get("url")
+        formats = info.get("formats",[])
+
+        best_combined = None
+        best_video = None
+        best_audio = None
+
+        for f in formats:
+            vcodec = f.get("vcodec", "none")
+            acodec = f.get("acodec", "none")
+            if vcodec != "none" and acodec != "none":
+                best_combined = f
+            if vcodec != "none" and acodec == "none":
+                best_video = f
+            if vcodec == "none" and acodec != "none":
+                best_audio = f
+
+        def _format_size(size_bytes):
+            if size_bytes is None: return "未知"
+            if size_bytes < 1024: return f"{size_bytes} B"
+            elif size_bytes < 1024**2: return f"{size_bytes/1024:.2f} KB"
+            elif size_bytes < 1024**3: return f"{size_bytes/1024**2:.2f} MB"
+            else: return f"{size_bytes/1024**3:.2f} GB"
+
+        lines =[]
+        lines.append(f"🎬 标题: {title}")
+        lines.append(f"⏱ 时长: {dur_str}")
+        lines.append("")
+
+        if best_combined and best_combined.get("url"):
+            res_h = best_combined.get("height", "?")
+            res_w = best_combined.get("width", "?")
+            ext = best_combined.get("ext", "?")
+            fsize = _format_size(best_combined.get("filesize") or best_combined.get("filesize_approx"))
+            lines.append(f"✅ 最佳合并流 ({res_w}x{res_h}, {ext}, {fsize}):\n{best_combined['url']}\n")
+        elif direct_url:
+            lines.append(f"✅ 直链:\n{direct_url}\n")
+        else:
+            lines.append("⚠️ 无合并流直链\n")
+
+        if best_video and best_video.get("url"):
+            res_h = best_video.get("height", "?")
+            res_w = best_video.get("width", "?")
+            ext = best_video.get("ext", "?")
+            vcodec = best_video.get("vcodec", "?")
+            fsize = _format_size(best_video.get("filesize") or best_video.get("filesize_approx"))
+            lines.append(f"🎥 最佳视频流 ({res_w}x{res_h}, {vcodec}, {ext}, {fsize}):\n{best_video['url']}\n")
+        
+        if best_audio and best_audio.get("url"):
+            acodec = best_audio.get("acodec", "?")
+            ext = best_audio.get("ext", "?")
+            fsize = _format_size(best_audio.get("filesize") or best_audio.get("filesize_approx"))
+            lines.append(f"🎵 最佳音频流 ({acodec}, {ext}, {fsize}):\n{best_audio['url']}\n")
+
+        lines.append("⚠️ 直链有时效性，请尽快使用。")
+
+        await event.send(event.plain_result("\n".join(lines)))
 
     @filter.event_message_type(EventMessageType.ALL)
     async def auto_parse(self, event: AstrMessageEvent):
-        """自动解析消息中的视频链接
-
-        Args:
-            event: 消息事件对象
-        """
-        # 白名单检查
+        """自动解析消息中的视频链接"""
         is_private = event.is_private_chat()
         sender_id = event.get_sender_id()
         group_id = None if is_private else event.get_group_id()
@@ -128,7 +209,6 @@ class VideoParserPlugin(Star):
                 msg_data = first_msg.data
                 curl_link = None
         
-                # 方式1: msg_data 已经是解析好的字典
                 if isinstance(msg_data, dict) and not msg_data.get('data'):
                     meta = msg_data.get("meta") or {}
                     detail_1 = meta.get("detail_1") or {}
@@ -137,7 +217,6 @@ class VideoParserPlugin(Star):
                         news = meta.get("news") or {}
                         curl_link = news.get("jumpUrl")
         
-                # 方式2: msg_data 是 {'data': 'json字符串'} 格式
                 if not curl_link:
                     json_str = msg_data.get('data', '') if isinstance(msg_data, dict) else msg_data
                     if json_str and isinstance(json_str, str):
@@ -197,23 +276,8 @@ class VideoParserPlugin(Star):
             
             if self.debug_mode:
                 self.logger.debug(f"解析获得 {len(metadata_list)} 条元数据")
-                for idx, metadata in enumerate(metadata_list):
-                    self.logger.debug(
-                        f"元数据[{idx}]: url={metadata.get('url')}, "
-                        f"video_count={len(metadata.get('video_urls', []))}, "
-                        f"image_count={len(metadata.get('image_urls', []))}, "
-                        f"video_force_download={metadata.get('video_force_download')}"
-                    )
             
             async def process_single_metadata(metadata: Dict[str, Any]) -> Dict[str, Any]:
-                """处理单个元数据
-
-                Args:
-                    metadata: 元数据字典
-
-                Returns:
-                    处理后的元数据字典，异常时包含error字段
-                """
                 if metadata.get('error'):
                     return metadata
                 
@@ -229,34 +293,25 @@ class VideoParserPlugin(Star):
                     metadata['error'] = str(e)
                     return metadata
             
-            tasks = [process_single_metadata(metadata) for metadata in metadata_list]
+            tasks =[process_single_metadata(metadata) for metadata in metadata_list]
             results = await asyncio.gather(*tasks, return_exceptions=True)
             
-            processed_metadata_list = []
+            processed_metadata_list =[]
             for i, result in enumerate(results):
                 if isinstance(result, Exception):
                     metadata = metadata_list[i] if i < len(metadata_list) else {}
                     error_msg = str(result)
-                    self.logger.exception(
-                        f"处理元数据时发生未捕获的异常: {metadata.get('url', '未知URL')}, "
-                        f"错误类型: {type(result).__name__}, 错误: {error_msg}"
-                    )
                     metadata['error'] = error_msg
                     processed_metadata_list.append(metadata)
                 elif isinstance(result, dict):
                     processed_metadata_list.append(result)
                 else:
                     metadata = metadata_list[i] if i < len(metadata_list) else {}
-                    error_msg = f'未知错误类型: {type(result).__name__}'
-                    self.logger.warning(
-                        f"处理元数据返回了意外的结果类型: {metadata.get('url', '未知URL')}, "
-                        f"类型: {type(result).__name__}"
-                    )
-                    metadata['error'] = error_msg
+                    metadata['error'] = f'未知错误类型: {type(result).__name__}'
                     processed_metadata_list.append(metadata)
             
             temp_files = []
-            video_files = []
+            video_files =[]
             try:
                 all_link_nodes, link_metadata, temp_files, video_files = self.message_manager.build_nodes(
                     processed_metadata_list,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 aiohttp
-
+yt-dlp
+imageio_ffmpeg


### PR DESCRIPTION
基于(https://github.com/204343414/astrbot_plugin_yt-dlp)项目将 yt-dlp 集成到了 astrbot_plugin_media_parser 中，实现了 YouTube 视频的解析与下载

 依赖文件
requirements.txt
修改：新增 yt-dlp 和 imageio_ffmpeg。
作用：核心下载库和音视频合并工具。

 配置文件与管理
_conf_schema.json
修改：
新增 enable_youtube 开关。
新增 proxy_settings 下的 youtube 代理开关。

core/config_manager.py
修改：
读取 enable_youtube 和代理配置。
在 create_parsers 中实例化 YoutubeParser。

 解析层 (Parser)
core/parser/platform/__init__.py
修改：导出 YoutubeParser。

core/parser/platform/youtube.py (新增)
逻辑：
使用 yt-dlp 的 extract_flat=True 模式快速获取标题和封面。
不伪装客户端（使用默认 Web 客户端），保证解析阶段兼容性。
捕获 Sign in to confirm 错误，如果是年龄限制视频，抛出明确的中文提示，不再尝试下载。
返回的 video_urls 带有 ytdlp: 前缀（如 ytdlp:https://youtu.be/xxx），供下载器识别。

下载层 (Downloader)
core/downloader/handler/__init__.py
修改：导出 download_ytdlp_to_cache。

core/downloader/handler/ytdlp.py (新增)
逻辑：
识别 ytdlp: 前缀并调用 yt-dlp 进行下载。
使用 imageio_ffmpeg 自动合并视频流和音频流。
关键策略：使用了 extractor_args: {'youtube': {'player_client': ['android']}} 伪装成 Android 客户端，有效绕过 "Requested format is not available" 风控。

core/downloader/router.py
修改：
在 detect_media_type 和 download_media 中增加对 ytdlp: 前缀的判断。
将 YouTube 任务分发给 download_ytdlp_to_cache。

core/downloader/manager.py
修改：
在 process_metadata 中，如果检测到 ytdlp: 前缀，强制启用预下载模式（因为 YouTube 视频必须在本地合并，无法直接发直链）。
在 _get_video_size_task 中跳过对 ytdlp: 链接的大小检查（yt-dlp 会自己处理）。

core/downloader/validator.py
修改：
在 get_video_size 和 validate_media_url 中跳过对 ytdlp: 链接的 HTTP 头检查。

 入口文件
main.py
修改：
新增了 @command("直链") 指令，允许用户通过 /直链 <url> 获取原始视频/音频流地址（仅解析不下载）。
确保 ConfigManager 被正确调用。