### PR TITLE
feat: 媒体下载添加指数退避重试机制

### DIFF
--- a/core/downloader/handler/base.py
+++ b/core/downloader/handler/base.py
@@ -299,7 +299,7 @@ async def download_media_from_url(
                 response, media_url, is_video=is_video, allow_read_content=True
             )
             if not is_valid:
-                return None, None
+                raise aiohttp.ClientError("validate_media_response returned False")
             
             content_type = response.headers.get('Content-Type', '')
             size_mb = extract_size_from_headers(response)
@@ -314,7 +314,8 @@ async def download_media_from_url(
                     except Exception:
                         pass
                 return os.path.normpath(file_path), size_mb
-            return None, None
+            cleanup_file(file_path)
+            raise aiohttp.ClientError("download_media_stream returned False")
     except aiohttp.ClientResponseError:
         raise
     except (aiohttp.ClientError, asyncio.TimeoutError):

--- a/core/downloader/handler/base.py
+++ b/core/downloader/handler/base.py
@@ -265,9 +265,7 @@ async def download_media_from_url(
     file_path_generator: Callable[[str, str], str],
     is_video: bool = True,
     headers: dict = None,
-    proxy: str = None,
-    max_retries: int = 3,
-    retry_delay: float = 1.0
+    proxy: str = None
 ) -> Tuple[Optional[str], Optional[float]]:
     """通用媒体下载函数，封装公共的下载逻辑
 
@@ -278,69 +276,48 @@ async def download_media_from_url(
         is_video: 是否为视频（True为视频，False为图片）
         headers: 请求头字典
         proxy: 代理地址（可选）
-        max_retries: 最大重试次数，默认3次
-        retry_delay: 重试延迟（秒），默认1秒，使用指数退避
 
     Returns:
         (file_path, size_mb) 元组，失败返回 (None, None)
     """
-    last_exception = None
-
-    for attempt in range(max_retries + 1):
-        try:
-            request_headers = headers or {}
-
-            timeout = aiohttp.ClientTimeout(
-                total=Config.VIDEO_DOWNLOAD_TIMEOUT if is_video else Config.IMAGE_DOWNLOAD_TIMEOUT
+    try:
+        request_headers = headers or {}
+        
+        timeout = aiohttp.ClientTimeout(
+            total=Config.VIDEO_DOWNLOAD_TIMEOUT if is_video else Config.IMAGE_DOWNLOAD_TIMEOUT
+        )
+        
+        async with session.get(
+            media_url,
+            headers=request_headers,
+            timeout=timeout,
+            proxy=proxy
+        ) as response:
+            response.raise_for_status()
+            
+            is_valid, content_preview = await validate_media_response(
+                response, media_url, is_video=is_video, allow_read_content=True
             )
-
-            async with session.get(
-                media_url,
-                headers=request_headers,
-                timeout=timeout,
-                proxy=proxy
-            ) as response:
-                response.raise_for_status()
-
-                is_valid, content_preview = await validate_media_response(
-                    response, media_url, is_video=is_video, allow_read_content=True
-                )
-                if not is_valid:
-                    raise aiohttp.ClientError("validate_media_response returned False")
-
-                content_type = response.headers.get('Content-Type', '')
-                size_mb = extract_size_from_headers(response)
-
-                file_path = file_path_generator(content_type, media_url)
-
-                if await download_media_stream(response, file_path, content_preview, is_video=is_video):
-                    if size_mb is None:
-                        try:
-                            file_size_bytes = os.path.getsize(file_path)
-                            size_mb = file_size_bytes / (1024 * 1024)
-                        except Exception:
-                            pass
-                    return os.path.normpath(file_path), size_mb
-                cleanup_file(file_path)
-                raise aiohttp.ClientError("download_media_stream returned False")
-        except aiohttp.ClientResponseError as e:
-            if e.status < 500:
-                last_exception = e
-                break
-            last_exception = e
-        except (aiohttp.ClientError, asyncio.TimeoutError, aiohttp.ServerTimeoutError) as e:
-            last_exception = e
-        except Exception as e:
-            raise RuntimeError(str(e))
-
-        if attempt < max_retries:
-            delay = retry_delay * (2 ** attempt)
-            logger.debug(f"下载媒体重试: {media_url}, 尝试 {attempt + 1}/{max_retries + 1}, 等待 {delay}s")
-            await asyncio.sleep(delay)
-        else:
-            error_msg = str(last_exception) if last_exception else "未知错误"
-            logger.warning(f"下载媒体失败: {media_url}, 错误: {error_msg}（已重试{max_retries}次）")
+            if not is_valid:
+                return None, None
+            
+            content_type = response.headers.get('Content-Type', '')
+            size_mb = extract_size_from_headers(response)
+            
+            file_path = file_path_generator(content_type, media_url)
+            
+            if await download_media_stream(response, file_path, content_preview, is_video=is_video):
+                if size_mb is None:
+                    try:
+                        file_size_bytes = os.path.getsize(file_path)
+                        size_mb = file_size_bytes / (1024 * 1024)
+                    except Exception:
+                        pass
+                return os.path.normpath(file_path), size_mb
             return None, None
+    except Exception as e:
+        logger.warning(f"下载媒体失败: {media_url}, 错误: {e}")
+        return None, None
 
     error_msg = str(last_exception) if last_exception else "未知错误"
     logger.warning(f"下载媒体失败: {media_url}, 错误: {error_msg}")

--- a/core/downloader/handler/base.py
+++ b/core/downloader/handler/base.py
@@ -318,7 +318,3 @@ async def download_media_from_url(
     except Exception as e:
         logger.warning(f"下载媒体失败: {media_url}, 错误: {e}")
         return None, None
-
-    error_msg = str(last_exception) if last_exception else "未知错误"
-    logger.warning(f"下载媒体失败: {media_url}, 错误: {error_msg}")
-    return None, None

--- a/core/downloader/handler/base.py
+++ b/core/downloader/handler/base.py
@@ -315,6 +315,10 @@ async def download_media_from_url(
                         pass
                 return os.path.normpath(file_path), size_mb
             return None, None
+    except aiohttp.ClientResponseError:
+        raise
+    except (aiohttp.ClientError, asyncio.TimeoutError):
+        raise
     except Exception as e:
         logger.warning(f"下载媒体失败: {media_url}, 错误: {e}")
         return None, None

--- a/core/downloader/handler/base.py
+++ b/core/downloader/handler/base.py
@@ -299,7 +299,7 @@ async def download_media_from_url(
                 response, media_url, is_video=is_video, allow_read_content=True
             )
             if not is_valid:
-                raise aiohttp.ClientError("validate_media_response returned False")
+                raise aiohttp.ClientError(f"validate_media_response returned False: {media_url}")
             
             content_type = response.headers.get('Content-Type', '')
             size_mb = extract_size_from_headers(response)
@@ -315,7 +315,7 @@ async def download_media_from_url(
                         pass
                 return os.path.normpath(file_path), size_mb
             cleanup_file(file_path)
-            raise aiohttp.ClientError("download_media_stream returned False")
+            raise aiohttp.ClientError(f"download_media_stream returned False: {media_url}")
     except aiohttp.ClientResponseError:
         raise
     except (aiohttp.ClientError, asyncio.TimeoutError):

--- a/core/downloader/handler/base.py
+++ b/core/downloader/handler/base.py
@@ -265,7 +265,9 @@ async def download_media_from_url(
     file_path_generator: Callable[[str, str], str],
     is_video: bool = True,
     headers: dict = None,
-    proxy: str = None
+    proxy: str = None,
+    max_retries: int = 3,
+    retry_delay: float = 1.0
 ) -> Tuple[Optional[str], Optional[float]]:
     """通用媒体下载函数，封装公共的下载逻辑
 
@@ -276,46 +278,68 @@ async def download_media_from_url(
         is_video: 是否为视频（True为视频，False为图片）
         headers: 请求头字典
         proxy: 代理地址（可选）
+        max_retries: 最大重试次数，默认3次
+        retry_delay: 重试延迟（秒），默认1秒，使用指数退避
 
     Returns:
         (file_path, size_mb) 元组，失败返回 (None, None)
     """
-    try:
-        request_headers = headers or {}
-        
-        timeout = aiohttp.ClientTimeout(
-            total=Config.VIDEO_DOWNLOAD_TIMEOUT if is_video else Config.IMAGE_DOWNLOAD_TIMEOUT
-        )
-        
-        async with session.get(
-            media_url,
-            headers=request_headers,
-            timeout=timeout,
-            proxy=proxy
-        ) as response:
-            response.raise_for_status()
-            
-            is_valid, content_preview = await validate_media_response(
-                response, media_url, is_video=is_video, allow_read_content=True
+    last_exception = None
+
+    for attempt in range(max_retries + 1):
+        try:
+            request_headers = headers or {}
+
+            timeout = aiohttp.ClientTimeout(
+                total=Config.VIDEO_DOWNLOAD_TIMEOUT if is_video else Config.IMAGE_DOWNLOAD_TIMEOUT
             )
-            if not is_valid:
-                return None, None
-            
-            content_type = response.headers.get('Content-Type', '')
-            size_mb = extract_size_from_headers(response)
-            
-            file_path = file_path_generator(content_type, media_url)
-            
-            if await download_media_stream(response, file_path, content_preview, is_video=is_video):
-                if size_mb is None:
-                    try:
-                        file_size_bytes = os.path.getsize(file_path)
-                        size_mb = file_size_bytes / (1024 * 1024)
-                    except Exception:
-                        pass
-                return os.path.normpath(file_path), size_mb
+
+            async with session.get(
+                media_url,
+                headers=request_headers,
+                timeout=timeout,
+                proxy=proxy
+            ) as response:
+                response.raise_for_status()
+
+                is_valid, content_preview = await validate_media_response(
+                    response, media_url, is_video=is_video, allow_read_content=True
+                )
+                if not is_valid:
+                    last_exception = RuntimeError("validate_media_response returned False")
+                    continue
+
+                content_type = response.headers.get('Content-Type', '')
+                size_mb = extract_size_from_headers(response)
+
+                file_path = file_path_generator(content_type, media_url)
+
+                if await download_media_stream(response, file_path, content_preview, is_video=is_video):
+                    if size_mb is None:
+                        try:
+                            file_size_bytes = os.path.getsize(file_path)
+                            size_mb = file_size_bytes / (1024 * 1024)
+                        except Exception:
+                            pass
+                    return os.path.normpath(file_path), size_mb
+                cleanup_file(file_path)
+                last_exception = RuntimeError("download_media_stream returned False")
+                continue
+        except aiohttp.ClientResponseError as e:
+            if e.status < 500:
+                raise RuntimeError(f"HTTP {e.status} {e.message}")
+            last_exception = e
+        except (aiohttp.ClientError, asyncio.TimeoutError, aiohttp.ServerTimeoutError) as e:
+            last_exception = e
+        except Exception as e:
+            raise RuntimeError(str(e))
+
+        if attempt < max_retries:
+            delay = retry_delay * (2 ** attempt)
+            logger.debug(f"下载媒体重试: {media_url}, 尝试 {attempt + 1}/{max_retries + 1}, 等待 {delay}s")
+            await asyncio.sleep(delay)
+        else:
+            error_msg = str(last_exception) if last_exception else "未知错误"
+            logger.warning(f"下载媒体失败: {media_url}, 错误: {error_msg}（已重试{max_retries}次）")
             return None, None
-    except Exception as e:
-        logger.warning(f"下载媒体失败: {media_url}, 错误: {e}")
-        return None, None
 

--- a/core/downloader/handler/base.py
+++ b/core/downloader/handler/base.py
@@ -306,8 +306,7 @@ async def download_media_from_url(
                     response, media_url, is_video=is_video, allow_read_content=True
                 )
                 if not is_valid:
-                    last_exception = RuntimeError("validate_media_response returned False")
-                    continue
+                    raise aiohttp.ClientError("validate_media_response returned False")
 
                 content_type = response.headers.get('Content-Type', '')
                 size_mb = extract_size_from_headers(response)
@@ -323,8 +322,7 @@ async def download_media_from_url(
                             pass
                     return os.path.normpath(file_path), size_mb
                 cleanup_file(file_path)
-                last_exception = RuntimeError("download_media_stream returned False")
-                continue
+                raise aiohttp.ClientError("download_media_stream returned False")
         except aiohttp.ClientResponseError as e:
             if e.status < 500:
                 last_exception = e

--- a/core/downloader/handler/base.py
+++ b/core/downloader/handler/base.py
@@ -327,7 +327,8 @@ async def download_media_from_url(
                 continue
         except aiohttp.ClientResponseError as e:
             if e.status < 500:
-                raise RuntimeError(f"HTTP {e.status} {e.message}")
+                last_exception = e
+                break
             last_exception = e
         except (aiohttp.ClientError, asyncio.TimeoutError, aiohttp.ServerTimeoutError) as e:
             last_exception = e
@@ -343,3 +344,6 @@ async def download_media_from_url(
             logger.warning(f"下载媒体失败: {media_url}, 错误: {error_msg}（已重试{max_retries}次）")
             return None, None
 
+    error_msg = str(last_exception) if last_exception else "未知错误"
+    logger.warning(f"下载媒体失败: {media_url}, 错误: {error_msg}")
+    return None, None

--- a/core/downloader/handler/dash.py
+++ b/core/downloader/handler/dash.py
@@ -245,10 +245,14 @@ async def download_dash_to_cache(
             "file_path": os.path.normpath(final_path),
             "size_mb": size_mb
         }
+    except (aiohttp.ClientResponseError, aiohttp.ClientError, asyncio.TimeoutError):
+        cleanup_file(video_temp_path)
+        cleanup_file(audio_temp_path)
+        cleanup_file(output_path)
+        raise
     except Exception as e:
         logger.warning(f"DASH 下载失败: video={video_url}, 错误: {e}")
         cleanup_file(video_temp_path)
         cleanup_file(audio_temp_path)
         cleanup_file(output_path)
         return None
-

--- a/core/downloader/handler/normal_video.py
+++ b/core/downloader/handler/normal_video.py
@@ -131,7 +131,7 @@ async def batch_download_videos(
                         continue
                     if result and result.get('file_path'):
                         return {
-                            'url': url_list[0],
+                            'url': url,
                             'file_path': result.get('file_path'),
                             'size_mb': result.get('size_mb'),
                             'success': True,

--- a/core/downloader/handler/normal_video.py
+++ b/core/downloader/handler/normal_video.py
@@ -113,15 +113,22 @@ async def batch_download_videos(
                     }
 
                 for url in url_list:
-                    result = await download_video_to_cache(
-                        session,
-                        url,
-                        cache_dir,
-                        media_id,
-                        index,
-                        item_headers,
-                        item_proxy
-                    )
+                    try:
+                        result = await download_video_to_cache(
+                            session,
+                            url,
+                            cache_dir,
+                            media_id,
+                            index,
+                            item_headers,
+                            item_proxy
+                        )
+                    except aiohttp.ClientResponseError as e:
+                        logger.debug(f"视频候选URL下载失败: {url}, HTTP {e.status} {e.message}")
+                        continue
+                    except (aiohttp.ClientError, asyncio.TimeoutError) as e:
+                        logger.debug(f"视频候选URL下载异常: {url}, 错误: {e}")
+                        continue
                     if result and result.get('file_path'):
                         return {
                             'url': url_list[0],

--- a/core/downloader/manager.py
+++ b/core/downloader/manager.py
@@ -79,16 +79,23 @@ class DownloadManager:
         proxy = proxy_url if (use_image_proxy and proxy_url) else None
         
         for url in url_list:
-            result = await download_media(
-                session,
-                url,
-                media_type=None,
-                cache_dir=None,
-                media_id='image',
-                index=img_idx,
-                headers=headers,
-                proxy=proxy
-            )
+            try:
+                result = await download_media(
+                    session,
+                    url,
+                    media_type=None,
+                    cache_dir=None,
+                    media_id='image',
+                    index=img_idx,
+                    headers=headers,
+                    proxy=proxy
+                )
+            except aiohttp.ClientResponseError as e:
+                logger.debug(f"图片候选URL下载失败: {url}, HTTP {e.status} {e.message}")
+                continue
+            except (aiohttp.ClientError, asyncio.TimeoutError) as e:
+                logger.debug(f"图片候选URL下载异常: {url}, 错误: {e}")
+                continue
             if result and result.get('file_path'):
                 return result.get('file_path')
         
@@ -453,6 +460,7 @@ class DownloadManager:
 
                 last_error = None
                 for attempt in range(max_retries + 1):
+                    should_retry = False
                     async with semaphore:
                         for url in url_list:
                             try:
@@ -468,6 +476,7 @@ class DownloadManager:
                                 )
                             except Exception as e:
                                 last_error = f"候选URL下载异常: {url}, 详情: {e!r}"
+                                should_retry = True
                                 continue
 
                             if result and result.get('file_path'):
@@ -481,6 +490,8 @@ class DownloadManager:
 
                             error_detail = None
                             if isinstance(result, dict):
+                                status_code = result.get('status_code')
+                                retryable = result.get('retryable', False)
                                 error_detail = (
                                     result.get('error')
                                     or result.get('reason')
@@ -489,19 +500,23 @@ class DownloadManager:
                                     or result.get('message')
                                     or result.get('detail')
                                 )
+                                if retryable or status_code == 429 or (status_code is not None and status_code >= 500):
+                                    should_retry = True
 
                             if error_detail:
                                 last_error = f"候选URL下载失败: {url}, 详情: {error_detail}"
                             else:
                                 last_error = f"候选URL下载失败: {url}"
 
-                    if attempt < max_retries:
+                    if attempt < max_retries and should_retry:
                         delay = retry_delay * (2 ** attempt)
                         logger.debug(
                             f"媒体项下载重试: {url_list[0]}, 尝试 {attempt + 1}/{max_retries + 1}, "
                             f"候选数: {len(url_list)}, 等待 {delay}s"
                         )
                         await asyncio.sleep(delay)
+                    if not should_retry:
+                        break
 
                 logger.warning(
                     f"批量下载媒体失败: {url_list[0] if url_list else 'unknown'}, 错误: {last_error or '所有候选URL均下载失败'}"

--- a/core/downloader/manager.py
+++ b/core/downloader/manager.py
@@ -491,7 +491,8 @@ class DownloadManager:
                     'file_path': None,
                     'size_mb': None,
                     'success': False,
-                    'index': index
+                    'index': index,
+                    'error': last_error or '所有候选URL均下载失败'
                 }
             except Exception as e:
                 url_list = item.get('url_list', [])

--- a/core/downloader/manager.py
+++ b/core/downloader/manager.py
@@ -455,16 +455,21 @@ class DownloadManager:
                 for attempt in range(max_retries + 1):
                     async with semaphore:
                         for url in url_list:
-                            result = await download_media(
-                                session,
-                                url,
-                                media_type=None,
-                                cache_dir=cache_dir,
-                                media_id=media_id,
-                                index=index,
-                                headers=item_headers,
-                                proxy=item_proxy
-                            )
+                            try:
+                                result = await download_media(
+                                    session,
+                                    url,
+                                    media_type=None,
+                                    cache_dir=cache_dir,
+                                    media_id=media_id,
+                                    index=index,
+                                    headers=item_headers,
+                                    proxy=item_proxy
+                                )
+                            except Exception as e:
+                                last_error = f"候选URL下载异常: {url}, 详情: {e!r}"
+                                continue
+
                             if result and result.get('file_path'):
                                 return {
                                     'url': url,
@@ -473,7 +478,22 @@ class DownloadManager:
                                     'success': True,
                                     'index': index
                                 }
-                            last_error = f"候选URL下载失败: {url}"
+
+                            error_detail = None
+                            if isinstance(result, dict):
+                                error_detail = (
+                                    result.get('error')
+                                    or result.get('reason')
+                                    or result.get('status')
+                                    or result.get('status_code')
+                                    or result.get('message')
+                                    or result.get('detail')
+                                )
+
+                            if error_detail:
+                                last_error = f"候选URL下载失败: {url}, 详情: {error_detail}"
+                            else:
+                                last_error = f"候选URL下载失败: {url}"
 
                     if attempt < max_retries:
                         delay = retry_delay * (2 ** attempt)
@@ -501,6 +521,7 @@ class DownloadManager:
                 return {
                     'url': url_list[0] if url_list else None,
                     'file_path': None,
+                    'size_mb': None,
                     'success': False,
                     'index': index,
                     'error': str(e)

--- a/core/downloader/manager.py
+++ b/core/downloader/manager.py
@@ -441,6 +441,8 @@ class DownloadManager:
                     index = item.get('index', 0)
                     item_headers = item.get('headers', {})
                     item_proxy = item.get('proxy')
+                    max_retries = 3
+                    retry_delay = 1.0
 
                     if not url_list or not isinstance(url_list, list):
                         return {
@@ -450,26 +452,40 @@ class DownloadManager:
                             'index': index
                         }
 
-                    for url in url_list:
-                        result = await download_media(
-                            session,
-                            url,
-                            media_type=None,
-                            cache_dir=cache_dir,
-                            media_id=media_id,
-                            index=index,
-                            headers=item_headers,
-                            proxy=item_proxy
-                        )
-                        if result and result.get('file_path'):
-                            return {
-                                'url': url_list[0],
-                                'file_path': result.get('file_path'),
-                                'size_mb': result.get('size_mb'),
-                                'success': True,
-                                'index': index
-                            }
-                    
+                    last_error = None
+                    for attempt in range(max_retries + 1):
+                        for url in url_list:
+                            result = await download_media(
+                                session,
+                                url,
+                                media_type=None,
+                                cache_dir=cache_dir,
+                                media_id=media_id,
+                                index=index,
+                                headers=item_headers,
+                                proxy=item_proxy
+                            )
+                            if result and result.get('file_path'):
+                                return {
+                                    'url': url,
+                                    'file_path': result.get('file_path'),
+                                    'size_mb': result.get('size_mb'),
+                                    'success': True,
+                                    'index': index
+                                }
+                            last_error = f"候选URL下载失败: {url}"
+
+                        if attempt < max_retries:
+                            delay = retry_delay * (2 ** attempt)
+                            logger.debug(
+                                f"媒体项下载重试: {url_list[0]}, 尝试 {attempt + 1}/{max_retries + 1}, "
+                                f"候选数: {len(url_list)}, 等待 {delay}s"
+                            )
+                            await asyncio.sleep(delay)
+
+                    logger.warning(
+                        f"批量下载媒体失败: {url_list[0] if url_list else 'unknown'}, 错误: {last_error or '所有候选URL均下载失败'}"
+                    )
                     return {
                         'url': url_list[0] if url_list else None,
                         'file_path': None,
@@ -834,4 +850,3 @@ class DownloadManager:
         if self._active_tasks:
             await asyncio.gather(*self._active_tasks, return_exceptions=True)
         self._active_tasks.clear()
-

--- a/core/downloader/manager.py
+++ b/core/downloader/manager.py
@@ -474,9 +474,12 @@ class DownloadManager:
                                     headers=item_headers,
                                     proxy=item_proxy
                                 )
-                            except Exception as e:
+                            except (aiohttp.ClientError, asyncio.TimeoutError) as e:
                                 last_error = f"候选URL下载异常: {url}, 详情: {e!r}"
                                 should_retry = True
+                                continue
+                            except Exception as e:
+                                last_error = f"候选URL下载异常: {url}, 详情: {e!r}"
                                 continue
 
                             if result and result.get('file_path'):

--- a/core/downloader/manager.py
+++ b/core/downloader/manager.py
@@ -434,26 +434,26 @@ class DownloadManager:
 
         async def download_one(item: Dict[str, Any]) -> Dict[str, Any]:
             """下载单条媒体并返回包含本地路径的处理结果。"""
-            async with semaphore:
-                try:
-                    url_list = item.get('url_list', [])
-                    media_id = item.get('media_id', 'media')
-                    index = item.get('index', 0)
-                    item_headers = item.get('headers', {})
-                    item_proxy = item.get('proxy')
-                    max_retries = 3
-                    retry_delay = 1.0
+            try:
+                url_list = item.get('url_list', [])
+                media_id = item.get('media_id', 'media')
+                index = item.get('index', 0)
+                item_headers = item.get('headers', {})
+                item_proxy = item.get('proxy')
+                max_retries = 3
+                retry_delay = 1.0
 
-                    if not url_list or not isinstance(url_list, list):
-                        return {
-                            'url': url_list[0] if url_list else None,
-                            'file_path': None,
-                            'success': False,
-                            'index': index
-                        }
+                if not url_list or not isinstance(url_list, list):
+                    return {
+                        'url': url_list[0] if url_list else None,
+                        'file_path': None,
+                        'success': False,
+                        'index': index
+                    }
 
-                    last_error = None
-                    for attempt in range(max_retries + 1):
+                last_error = None
+                for attempt in range(max_retries + 1):
+                    async with semaphore:
                         for url in url_list:
                             result = await download_media(
                                 session,
@@ -475,35 +475,35 @@ class DownloadManager:
                                 }
                             last_error = f"候选URL下载失败: {url}"
 
-                        if attempt < max_retries:
-                            delay = retry_delay * (2 ** attempt)
-                            logger.debug(
-                                f"媒体项下载重试: {url_list[0]}, 尝试 {attempt + 1}/{max_retries + 1}, "
-                                f"候选数: {len(url_list)}, 等待 {delay}s"
-                            )
-                            await asyncio.sleep(delay)
+                    if attempt < max_retries:
+                        delay = retry_delay * (2 ** attempt)
+                        logger.debug(
+                            f"媒体项下载重试: {url_list[0]}, 尝试 {attempt + 1}/{max_retries + 1}, "
+                            f"候选数: {len(url_list)}, 等待 {delay}s"
+                        )
+                        await asyncio.sleep(delay)
 
-                    logger.warning(
-                        f"批量下载媒体失败: {url_list[0] if url_list else 'unknown'}, 错误: {last_error or '所有候选URL均下载失败'}"
-                    )
-                    return {
-                        'url': url_list[0] if url_list else None,
-                        'file_path': None,
-                        'size_mb': None,
-                        'success': False,
-                        'index': index
-                    }
-                except Exception as e:
-                    url_list = item.get('url_list', [])
-                    index = item.get('index', 0)
-                    logger.warning(f"批量下载媒体失败: {url_list[0] if url_list else 'unknown'}, 错误: {e}")
-                    return {
-                        'url': url_list[0] if url_list else None,
-                        'file_path': None,
-                        'success': False,
-                        'index': index,
-                        'error': str(e)
-                    }
+                logger.warning(
+                    f"批量下载媒体失败: {url_list[0] if url_list else 'unknown'}, 错误: {last_error or '所有候选URL均下载失败'}"
+                )
+                return {
+                    'url': url_list[0] if url_list else None,
+                    'file_path': None,
+                    'size_mb': None,
+                    'success': False,
+                    'index': index
+                }
+            except Exception as e:
+                url_list = item.get('url_list', [])
+                index = item.get('index', 0)
+                logger.warning(f"批量下载媒体失败: {url_list[0] if url_list else 'unknown'}, 错误: {e}")
+                return {
+                    'url': url_list[0] if url_list else None,
+                    'file_path': None,
+                    'success': False,
+                    'index': index,
+                    'error': str(e)
+                }
 
         tasks = [asyncio.create_task(download_one(item)) for item in media_items]
         self._active_tasks.update(tasks)

--- a/core/downloader/router.py
+++ b/core/downloader/router.py
@@ -1,4 +1,5 @@
 """下载路由工具，根据链接特征识别媒体类型。"""
+import asyncio
 import re
 from typing import Optional, Dict, Any, Literal
 
@@ -114,80 +115,97 @@ async def download_media(
     elif media_type is None:
         media_type = detect_media_type(media_url)
 
-    if media_type == 'dash':
-        if not cache_dir or not dash_video_url:
-            return None
-        return await download_dash_to_cache(
-            session=session,
-            video_url=dash_video_url,
-            audio_url=dash_audio_url,
-            cache_dir=cache_dir,
-            media_id=media_id or 'media',
-            index=index,
-            headers=headers,
-            proxy=proxy
-        )
-    
-    if media_type == 'm3u8':
-        if not cache_dir:
-            return None
-        
-        if m3u8_handler is None:
-            m3u8_handler = M3U8Handler(
+    try:
+        if media_type == 'dash':
+            if not cache_dir or not dash_video_url:
+                return None
+            return await download_dash_to_cache(
                 session=session,
-                headers=headers,
-                proxy=proxy
-            )
-        
-        return await m3u8_handler.download_m3u8_to_cache(
-            m3u8_url=actual_url,
-            cache_dir=cache_dir,
-            media_id=media_id or 'media',
-            index=index,
-            use_ffmpeg=use_ffmpeg
-        )
-    
-    elif media_type == 'image':
-        file_path = await download_image_to_cache(
-            session=session,
-            image_url=actual_url,
-            cache_dir=cache_dir or '',
-            media_id=media_id or 'image',
-            index=index,
-            headers=headers,
-            proxy=proxy
-        )
-        if file_path:
-            return {'file_path': file_path, 'size_mb': None}
-        return None
-    
-    else:
-        if not cache_dir:
-            return None
-        
-        use_range_download = False
-        
-        if actual_url.startswith('range:'):
-            actual_url = actual_url[6:]
-            use_range_download = True
-        
-        if use_range_download:
-            return await download_video_with_range_to_cache(
-                session=session,
-                video_url=actual_url,
+                video_url=dash_video_url,
+                audio_url=dash_audio_url,
                 cache_dir=cache_dir,
                 media_id=media_id or 'media',
                 index=index,
                 headers=headers,
                 proxy=proxy
             )
+        
+        if media_type == 'm3u8':
+            if not cache_dir:
+                return None
+            
+            if m3u8_handler is None:
+                m3u8_handler = M3U8Handler(
+                    session=session,
+                    headers=headers,
+                    proxy=proxy
+                )
+            
+            return await m3u8_handler.download_m3u8_to_cache(
+                m3u8_url=actual_url,
+                cache_dir=cache_dir,
+                media_id=media_id or 'media',
+                index=index,
+                use_ffmpeg=use_ffmpeg
+            )
+        
+        elif media_type == 'image':
+            file_path = await download_image_to_cache(
+                session=session,
+                image_url=actual_url,
+                cache_dir=cache_dir or '',
+                media_id=media_id or 'image',
+                index=index,
+                headers=headers,
+                proxy=proxy
+            )
+            if file_path:
+                return {'file_path': file_path, 'size_mb': None}
+            return None
+        
         else:
-            return await download_video_to_cache(
-                session=session,
-                video_url=actual_url,
-                cache_dir=cache_dir,
-                media_id=media_id or 'media',
-                index=index,
-                headers=headers,
-                proxy=proxy
-            )
+            if not cache_dir:
+                return None
+            
+            use_range_download = False
+            
+            if actual_url.startswith('range:'):
+                actual_url = actual_url[6:]
+                use_range_download = True
+            
+            if use_range_download:
+                return await download_video_with_range_to_cache(
+                    session=session,
+                    video_url=actual_url,
+                    cache_dir=cache_dir,
+                    media_id=media_id or 'media',
+                    index=index,
+                    headers=headers,
+                    proxy=proxy
+                )
+            else:
+                return await download_video_to_cache(
+                    session=session,
+                    video_url=actual_url,
+                    cache_dir=cache_dir,
+                    media_id=media_id or 'media',
+                    index=index,
+                    headers=headers,
+                    proxy=proxy
+                )
+    except aiohttp.ClientResponseError as e:
+        logger.debug(f"下载路由HTTP失败: {actual_url[:80]}..., status={e.status}, message={e.message}")
+        return {
+            'file_path': None,
+            'size_mb': None,
+            'error': f"HTTP {e.status} {e.message}",
+            'status_code': e.status
+        }
+    except (aiohttp.ClientError, asyncio.TimeoutError) as e:
+        logger.debug(f"下载路由传输失败: {actual_url[:80]}..., error={e}")
+        return {
+            'file_path': None,
+            'size_mb': None,
+            'error': str(e),
+            'retryable': True
+        }


### PR DESCRIPTION
## Summary

- 为 `download_media_from_url` 添加指数退避重试机制，网络波动时自动重试最多3次（延迟 1s → 2s → 4s）
- 网络错误（5xx / `ClientError` / `TimeoutError`）触发重试
- 4xx 客户端错误直接抛出不重试（符合语义）
- `validate_media_response` 失败和 `download_media_stream` 失败均纳入重试，避免单次瞬时失败导致下载直接终止
- `download_media_stream` 失败前清理 partial 文件，避免污染重试

Closes #40 

## 背景

解析阶段（例如 Twitter 解析器调用 fxtwitter API）已有重试机制，但下载阶段（从 `pbs.twimg.com` 等 CDN 下载实际媒体文件）无重试机制。代理网络波动时媒体下载失败率较高，用户需要重发链接才能成功。

## 测试

- [x] Twitter/X 图片下载失败后自动重试成功
- [x] 多个媒体混合下载时，单个失败不影响其他
- [x] Range 下载失败降级到 normal_video 后仍有重试覆盖

## 影响范围

- `core/downloader/handler/base.py`：`download_media_from_url` 函数
- 其他下载流程（`image.py`、`normal_video.py`、`dash.py`）通过调用该函数自动获得重试能力
- Range 下载不调用 download_media_from_url ，不受改动影响