### PR TITLE
[codex] Fix b23.tv short link expansion

### DIFF
--- a/core/parser/manager.py
+++ b/core/parser/manager.py
@@ -1,5 +1,6 @@
 """解析管理器，维护解析器列表并按链接匹配。"""
 import asyncio
+import traceback
 from typing import List, Dict, Any, Optional, Tuple
 
 import aiohttp
@@ -92,7 +93,16 @@ class ParserManager:
                 if isinstance(result, SkipParse):
                     logger.debug(f"跳过解析: {url}, 原因: {result}")
                     continue
-                logger.exception(f"解析URL失败: {url}, 错误: {result}")
+                error_traceback = "".join(
+                    traceback.format_exception(
+                        type(result),
+                        result,
+                        result.__traceback__
+                    )
+                ).strip()
+                logger.error(
+                    f"解析URL失败: {url}, 错误: {result}\n{error_traceback}"
+                )
                 metadata_list.append({
                     'url': url,
                     'source_url': url,

--- a/core/parser/platform/bilibili.py
+++ b/core/parser/platform/bilibili.py
@@ -7,7 +7,7 @@ import time
 from datetime import datetime
 from pathlib import Path
 from typing import Optional, Dict, Any, Tuple, List
-from urllib.parse import urlparse, parse_qs, urlencode
+from urllib.parse import urlparse, parse_qs, urlencode, urljoin
 
 import aiohttp
 
@@ -706,7 +706,7 @@ class BilibiliParser(BaseVideoParser):
         Returns:
             展开后的URL，如果展开失败返回原URL
         """
-        if urlparse(url).netloc.lower() == B23_HOST:
+        if urlparse(url).hostname == B23_HOST:
             headers = {
                 "User-Agent": UA,
                 "Referer": "https://www.bilibili.com",
@@ -716,13 +716,24 @@ class BilibiliParser(BaseVideoParser):
                 async with session.get(
                     url,
                     headers=headers,
-                    allow_redirects=True,
+                    allow_redirects=False,
                     timeout=aiohttp.ClientTimeout(total=10)
                 ) as r:
+                    location = r.headers.get("Location")
+                    if location:
+                        return urljoin(str(r.url), location)
                     expanded_url = str(r.url)
-                    return expanded_url
-            except Exception:
-                return url
+                    if expanded_url != url:
+                        return expanded_url
+                    logger.debug(
+                        f"[{self.name}] expand_b23: 未获取到重定向地址 "
+                        f"{url}, status={r.status}"
+                    )
+            except Exception as e:
+                logger.debug(
+                    f"[{self.name}] expand_b23: 获取短链重定向失败 "
+                    f"{url}, 错误: {e}"
+                )
         return url
 
     def extract_p(self, url: str) -> int:


### PR DESCRIPTION
## Summary

Fixes Bilibili b23.tv short link expansion and parser error logging.

## Root cause

`expand_b23()` followed all redirects and returned the final response URL. In some environments, following the first b23.tv redirect into the Bilibili web page can hit an anti-bot/precondition response instead of preserving the canonical video URL. When that happens, parsing falls back to the original b23.tv link, which `detect_target()` cannot classify as BV/AV/PGC.

`ParserManager.parse_text()` also used `logger.exception()` after `asyncio.gather(..., return_exceptions=True)`, outside an active exception context. That produced misleading `NoneType: None` log output.

## Changes

- Read the first b23.tv `Location` header with redirects disabled and return it via `urljoin()`.
- Keep debug logging when the short link does not provide a redirect or the request fails.
- Format gathered exceptions explicitly so logs include the actual traceback instead of `NoneType: None`.

## Validation

- `python -m py_compile core\parser\platform\bilibili.py core\parser\manager.py`
- `git diff --check`
- Verified the reported b23.tv link returns a 302 Location containing `BV1WKo4BpENa`.
