### PR TITLE
fix: handle douyin note gallery play urls

### DIFF
--- a/core/parser/platform/douyin.py
+++ b/core/parser/platform/douyin.py
@@ -3,7 +3,7 @@ import asyncio
 import json
 import re
 from typing import Any, Dict, List, Optional
-from urllib.parse import urlparse
+from urllib.parse import parse_qs, urlparse
 
 import aiohttp
 
@@ -149,6 +149,22 @@ class DouyinParser(ShortVideoParserMixin, BaseVideoParser):
         )
 
     @staticmethod
+    def _is_malformed_douyin_play_url(url: str) -> bool:
+        try:
+            parsed = urlparse(str(url or ""))
+        except Exception:
+            return False
+
+        if "/aweme/v1/play" not in (parsed.path or "").lower():
+            return False
+
+        video_ids = parse_qs(parsed.query or "").get("video_id") or []
+        return any(
+            str(video_id).strip().lower().startswith(("http://", "https://"))
+            for video_id in video_ids
+        )
+
+    @staticmethod
     def _looks_like_audio_url(url: str) -> bool:
         normalized = str(url or "").lower()
         if not normalized.startswith(("http://", "https://")):
@@ -171,6 +187,8 @@ class DouyinParser(ShortVideoParserMixin, BaseVideoParser):
         if not normalized.startswith(("http://", "https://")):
             return False
         if cls._looks_like_audio_url(normalized):
+            return False
+        if cls._is_malformed_douyin_play_url(normalized):
             return False
         return any(
             marker in normalized


### PR DESCRIPTION
## 概要

修复抖音图文/相册解析问题：当页面暴露一个格式异常的 `playwm` URL，且其 `video_id` 查询参数本身是一个完整的 CDN URL 时，解析会出错。

## 根因

部分抖音图文笔记页面会包含一个顶层的 `video.play_addr.url_list` 条目，例如：

`https://aweme.snssdk.com/aweme/v1/playwm/?video_id=https://...&ratio=720p&line=0`

解析器之前会把任何包含 `video_id=` 的 URL 都当作视频 URL，因此这些图文笔记会被分类为 `video_urls=[...]`，而 `image_urls=[]`。下载这个格式异常的播放 URL 会返回 HTTP 404，但真正的媒体内容其实位于该笔记的 `images` 列表中。

## 变更

* 为抖音 `play` / `playwm` URL 增加保护逻辑：当其 `video_id` 的值以 `http://` 或 `https://` 开头时进行拦截。
* 将这些格式异常的播放 URL 从视频 URL 检测逻辑中排除，这样图文笔记解析就可以回退到现有的图片提取路径。

## 验证

* `python -m compileall core\parser\platform\douyin.py`
* 使用形如 `playwm/?video_id=https://...` 的异常 URL 结构进行本地回归检查，确认它不再被识别为视频，并且图片列表能够正常保留。

关联issue #69 
