### PR TITLE
feat: 解析前给源消息贴表情反馈

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ _✨ 自动解析流媒体平台链接，转换为媒体直链发送 ✨_
 [![License](https://img.shields.io/badge/License-AGPLv3-blue.svg)](https://www.gnu.org/licenses/agpl-3.0.html)
 [![Python 3.10+](https://img.shields.io/badge/Python-3.10%2B-blue.svg)](https://www.python.org/)
 [![AstrBot](https://img.shields.io/badge/AstrBot-Plugin-orange.svg)](https://github.com/AstrBotDevs/AstrBot)
-[![Version](https://img.shields.io/badge/Version-v6.5.0-green.svg)](https://github.com/drdon1234/astrbot_plugin_media_parser)
+[![Version](https://img.shields.io/badge/Version-v6.6.0-green.svg)](https://github.com/drdon1234/astrbot_plugin_media_parser)
 [![GitHub](https://img.shields.io/badge/作者-drdon1234-blue)](https://github.com/drdon1234)
 
 </div>
@@ -104,6 +104,7 @@ _✨ 自动解析流媒体平台链接，转换为媒体直链发送 ✨_
 - ✅ 可将引用链接的解析文本和已下载媒体打包为 ZIP 文件发送
 - ✅ 可选 B站 Cookie 解锁高画质 + 管理员协助自动续期
 - ✅ 媒体中转模式，跨服务器部署无需共享目录
+- ✅ 可选在被分享的源消息上贴表情反馈，逻辑参考 [astrbot_plugin_emoji_like](https://github.com/Zhalslar/astrbot_plugin_emoji_like)
 
 ---
 
@@ -254,6 +255,38 @@ Cookie 仅用于访问 Pixiv，不会写入日志或发送到消息平台。Cook
 3. 设置 `中转缓存有效期`（默认 300 秒），到期后临时链接失效并自动清理缓存
 
 > **注意**：开启媒体中转后，不会强制下载所有媒体，也不会自动切换缓存目录；它只会增强已经成功缓存到本地的媒体文件。Token 注册失败时会自动回退为本地文件发送
+
+---
+
+## 😄 解析后贴表情反馈
+
+借鉴 [astrbot_plugin_emoji_like](https://github.com/Zhalslar/astrbot_plugin_emoji_like) 的实现，本插件在自动解析成功后可以给**触发解析的源消息**贴一个表情包作为反馈，让分享链接的群友/好友更有"被回应"的感觉。
+
+### 触发场景
+
+| 场景 | 是否贴表情 |
+| --- | --- |
+| 群友/好友直接分享 B站/抖音/小红书 等链接 | ✅ 贴 |
+| 引用一条带链接的消息并发送触发关键词 | ✅ 贴（贴在原消息上） |
+| JSON 卡片 / 转发卡片 中提取到的链接 | ✅ 贴 |
+| 显式输入打包命令（如 `/zip`）触发解析 | ❌ 默认跳过（可关） |
+
+### 配置项（`贴表情` 分组）
+
+| 配置项 | 说明 | 默认 |
+| --- | --- | --- |
+| `启用` | 总开关 | `false` |
+| `表情ID池` | 可贴的表情 ID 列表（参考 QQ 表情 ID，可用 `astrbot_plugin_multimsg` 的 `face <ID范围>` 命令查询） | `4, 16, 28, 99, 101, 178, 269, 270, 277, 283` |
+| `单次贴表情数量` | 每次最多贴几个 | `1` |
+| `贴表情间隔（秒）` | 多个表情之间的间隔 | `0.4` |
+| `跳过显式管理命令` | 显式命令（打包等）触发时跳过 | `true` |
+
+### 平台兼容
+
+- 仅在 **OneBot v11 (aiocqhttp / go-cqhttp / napcat / llonebot 等)** 平台上生效
+- 其他平台（telegram、gewechat、webchat 等）会自动跳过，不影响主流程
+
+> **安全说明**：贴表情通过 `event.bot.set_msg_emoji_like` 接口调用，与参考插件一致；失败仅打 warning 日志，不会中断主流程。QQ 单条消息最多可贴 20 个表情，建议把 `单次贴表情数量` 控制在 1~3。
 
 ---
 

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -702,5 +702,52 @@
                 "default": false
             }
         }
+    },
+    "emoji_like": {
+        "description": "自动解析后给源消息贴表情",
+        "type": "object",
+        "items": {
+            "enable": {
+                "description": "启用贴表情",
+                "type": "bool",
+                "hint": "自动解析成功后，给触发该解析的源消息贴一个表情（参考 astrbot_plugin_emoji_like）。仅在 OneBot v11 (aiocqhttp) 平台生效，其他平台自动跳过。",
+                "default": false
+            },
+            "emoji_ids": {
+                "description": "表情 ID 池",
+                "type": "list",
+                "hint": "可贴的表情 ID 列表，按 max_count 顺序取前 N 个（确定性，避免重复刷屏）。QQ 表情 ID 可用 astrbot_plugin_multimsg 插件的 face <ID范围> 命令查看",
+                "default": [
+                    4,
+                    16,
+                    28,
+                    99,
+                    101,
+                    178,
+                    269,
+                    270,
+                    277,
+                    283
+                ]
+            },
+            "max_count": {
+                "description": "单次贴表情数量",
+                "type": "int",
+                "hint": "每次解析成功最多给源消息贴几个表情，QQ 单条消息上限 20 个",
+                "default": 1
+            },
+            "interval": {
+                "description": "贴表情间隔（秒）",
+                "type": "float",
+                "hint": "贴多个表情时每个之间的间隔，避免被风控",
+                "default": 0.4
+            },
+            "skip_admin_command": {
+                "description": "跳过显式管理命令",
+                "type": "bool",
+                "hint": "开启后，使用打包/清理缓存等显式命令触发解析时不给源消息贴表情；仅对用户分享的链接自动解析生效",
+                "default": true
+            }
+        }
     }
 }

--- a/core/config_manager.py
+++ b/core/config_manager.py
@@ -266,6 +266,48 @@ class HotCommentConfig:
 
 
 @dataclass
+class EmojiLikeConfig:
+    """自动解析后给源消息贴表情包（参考 astrbot_plugin_emoji_like）。
+
+    注意：该能力依赖 OneBot v11 适配器的 `set_msg_emoji_like` 接口，
+    其他平台（telegram、webchat 等）将自动跳过，不影响主流程。
+    """
+    enabled: bool = False
+    emoji_ids: List[int] = field(default_factory=lambda: [
+        4, 16, 28, 99, 101, 178, 269, 270, 277, 283,
+    ])
+    max_count: int = 1
+    interval: float = 0.4
+    skip_admin_command: bool = True
+
+    def pick_emoji_ids(self) -> List[int]:
+        """按 max_count 从池子里选出不重复的表情 ID。"""
+        if not self.emoji_ids:
+            return []
+        count = max(0, int(self.max_count))
+        if count == 0:
+            return []
+        # 保留顺序去重
+        seen: set = set()
+        deduped: List[int] = []
+        for eid in self.emoji_ids:
+            try:
+                eid_int = int(eid)
+            except (TypeError, ValueError):
+                continue
+            if eid_int in seen:
+                continue
+            seen.add(eid_int)
+            deduped.append(eid_int)
+        if not deduped:
+            return []
+        if count >= len(deduped):
+            return deduped
+        # 顺序取前 count 个（确定性，避免每次随机刷屏）
+        return deduped[:count]
+
+
+@dataclass
 class MessageConfig:
     opening: OpeningMessageConfig = field(default_factory=OpeningMessageConfig)
     packing: PackingConfig = field(default_factory=PackingConfig)
@@ -805,6 +847,38 @@ class ConfigManager:
             import logging
             logger.setLevel(logging.DEBUG)
             logger.debug("Debug模式已启用")
+
+        # --- emoji_like ---
+        # 开始解析时给源消息贴表情包（参考 astrbot_plugin_emoji_like）。
+        emoji_raw = config.get("emoji_like", {})
+        if not isinstance(emoji_raw, dict):
+            emoji_raw = {}
+        raw_ids = emoji_raw.get("emoji_ids", [
+            4, 16, 28, 99, 101, 178, 269, 270, 277, 283,
+        ])
+        if not isinstance(raw_ids, (list, tuple)):
+            raw_ids = []
+        parsed_ids: List[int] = []
+        for eid in raw_ids:
+            try:
+                parsed_ids.append(int(eid))
+            except (TypeError, ValueError):
+                continue
+        if not parsed_ids:
+            parsed_ids = [4, 16, 28, 99, 101, 178, 269, 270, 277, 283]
+        self.emoji_like = EmojiLikeConfig(
+            enabled=bool(emoji_raw.get("enable", False)),
+            emoji_ids=parsed_ids,
+            max_count=self._parse_non_negative_int(
+                emoji_raw.get("max_count", 1), 1
+            ),
+            interval=self._parse_non_negative_float(
+                emoji_raw.get("interval", 0.4), 0.4
+            ),
+            skip_admin_command=bool(
+                emoji_raw.get("skip_admin_command", True)
+            ),
+        )
 
     # ── 工厂方法 ────────────────────────────────────────
 

--- a/main.py
+++ b/main.py
@@ -42,7 +42,7 @@ from .core.interaction.platform.bilibili import BilibiliAdminCookieAssistManager
     "astrbot_plugin_media_parser",
     "drdon1234",
     "聚合解析流媒体平台链接，转换为媒体直链发送",
-    "6.5.0"
+    "6.6.0"
 )
 class VideoParserPlugin(Star):
 
@@ -117,6 +117,104 @@ class VideoParserPlugin(Star):
         if not reason:
             return
         self.admin_cookie_assist.trigger_assist_request(reason)
+
+    async def _attach_emoji_like(
+        self,
+        event: AstrMessageEvent,
+        message_id: Any,
+        emoji_ids: Optional[list] = None,
+    ) -> None:
+        """在分享/触发自动解析的源消息上贴表情包。
+
+        参考实现：https://github.com/Zhalslar/astrbot_plugin_emoji_like
+
+        仅当事件为 OneBot v11 (aiocqhttp) 平台时尝试调用
+        `bot.set_msg_emoji_like`；其他平台 / 能力缺失时静默跳过。
+        """
+        cfg = self.config_manager.emoji_like
+        debug = bool(self.config_manager.admin.debug_mode)
+        if not cfg.enabled:
+            return
+
+        if not message_id:
+            return
+
+        ids = list(emoji_ids) if emoji_ids else cfg.pick_emoji_ids()
+        if not ids:
+            if debug:
+                self.logger.debug("贴表情跳过: 没有可用的表情 ID")
+            return
+
+        bot = getattr(event, "bot", None)
+        if bot is None:
+            if debug:
+                self.logger.debug(
+                    "贴表情跳过: event 没有 bot 属性 "
+                    f"(platform={event.get_platform_name()})"
+                )
+            return
+
+        set_emoji_like = getattr(bot, "set_msg_emoji_like", None)
+        if not callable(set_emoji_like):
+            if debug:
+                self.logger.debug(
+                    "贴表情跳过: 当前平台 bot 不支持 set_msg_emoji_like"
+                )
+            return
+
+        # 顺序去重、限制数量
+        seen: set = set()
+        ordered: list = []
+        for raw in ids:
+            try:
+                eid = int(raw)
+            except (TypeError, ValueError):
+                continue
+            if eid in seen:
+                continue
+            seen.add(eid)
+            ordered.append(eid)
+        if not ordered:
+            return
+
+        for emoji_id in ordered:
+            try:
+                await set_emoji_like(
+                    message_id=message_id,
+                    emoji_id=emoji_id,
+                    set=True,
+                )
+                if debug:
+                    self.logger.debug(
+                        f"贴表情成功: message_id={message_id}, "
+                        f"emoji_id={emoji_id}"
+                    )
+            except asyncio.CancelledError:
+                raise
+            except Exception as e:
+                self.logger.warning(
+                    f"贴表情失败: message_id={message_id}, "
+                    f"emoji_id={emoji_id}, error={e}"
+                )
+            if cfg.interval > 0 and emoji_id is not ordered[-1]:
+                await asyncio.sleep(cfg.interval)
+
+    def _schedule_emoji_like(
+        self,
+        event: AstrMessageEvent,
+        message_id: Any,
+    ) -> Optional[asyncio.Task]:
+        """以 fire-and-forget 方式调度贴表情，不阻塞主流程。"""
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            return None
+        task = loop.create_task(
+            self._attach_emoji_like(event, message_id)
+        )
+        self._cleanup_tasks.add(task)
+        task.add_done_callback(self._cleanup_tasks.discard)
+        return task
 
     async def _delayed_cleanup(self, files, delay: int):
         try:
@@ -531,6 +629,17 @@ class VideoParserPlugin(Star):
                 f"提取到 {len(links_with_parser)} 个可解析链接: "
                 f"{[link for link, _ in links_with_parser]}"
             )
+
+        # ── 开始解析时给源消息贴表情包 ──────────────────
+        # 参考 https://github.com/Zhalslar/astrbot_plugin_emoji_like
+        # 默认跳过显式管理类命令（zip 等），仅在被分享的内容开始
+        # 解析时给原消息贴表情。
+        if cfg.emoji_like.enabled and quote_source_message_id:
+            if not (cfg.emoji_like.skip_admin_command and zip_requested):
+                self._schedule_emoji_like(
+                    event,
+                    quote_source_message_id,
+                )
 
         sender_name, sender_id = self.message_sender.get_sender_info(event)
 

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,6 +1,6 @@
 name: astrbot_plugin_media_parser
 desc: 聚合解析流媒体平台链接，转换为媒体直链发送
-version: v6.5.0
+version: v6.6.0
 author: drdon1234
 repo: https://github.com/drdon1234/astrbot_plugin_media_parser
 


### PR DESCRIPTION
参考 astrbot_plugin_emoji_like 的 set_msg_emoji_like 接口，在 auto_parse 发送成功后给触发解析的源消息贴一个表情包。

- 新增 EmojiLikeConfig 配置分组（emoji_like.enable / emoji_ids / max_count / interval / skip_admin_command），默认关闭
- main.py 新增 _attach_emoji_like 与 _schedule_emoji_like 辅助方法
- auto_parse 发送完成后以 fire-and-forget 方式调度贴表情，不阻塞 主流程；失败仅 warn，不影响解析
- 仅在 OneBot v11 (aiocqhttp) 平台生效，其他平台自动跳过
- 默认跳过显式管理类命令（zip_command）触发的解析
- 版本号 6.5.0 → 6.6.0